### PR TITLE
override query_has_constraints and has_search_parameters so appropriate ...

### DIFF
--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -27,6 +27,14 @@ module BlacklightRangeLimit
       end
 
       unless omit_inject[:view_helpers]
+
+        CatalogController.send(:helper, 
+          BlacklightRangeLimit::ViewHelperOverride
+        ) unless
+          CatalogController.helpers.is_a?( 
+            BlacklightRangeLimit::ViewHelperOverride
+          )
+
         SearchHistoryController.send(:helper, 
           BlacklightRangeLimit::ViewHelperOverride
         ) unless
@@ -39,6 +47,13 @@ module BlacklightRangeLimit
         ) unless
           SearchHistoryController.helpers.is_a?( 
             RangeLimitHelper
+          )
+          
+        SavedSearchesController.send(:helper, 
+          BlacklightRangeLimit::ViewHelperOverride
+        ) unless
+          SavedSearchesController.helpers.is_a?( 
+            BlacklightRangeLimit::ViewHelperOverride
           )
       end
       

--- a/lib/blacklight_range_limit/view_helper_override.rb
+++ b/lib/blacklight_range_limit/view_helper_override.rb
@@ -3,8 +3,15 @@
   # display. 
   module BlacklightRangeLimit::ViewHelperOverride
 
+    def query_has_constraints?(localized_params = params)
+      !(localized_params[:q].blank? and localized_params[:f].blank? and localized_params[:range].blank?)
+    end
 
-    
+    def has_search_parameters?
+      !params[:q].blank? or !params[:f].blank? or !params[:search_field].blank? or !params[:range].blank?
+    end
+
+   
     def facet_partial_name(display_facet)
       return "blacklight_range_limit/range_limit_panel" if range_config(display_facet.name) and should_show_limit(display_facet.name)
       super

--- a/spec/features/blacklight_range_limit_spec.rb
+++ b/spec/features/blacklight_range_limit_spec.rb
@@ -4,7 +4,7 @@ describe "Blacklight Range Limit" do
   before do
     CatalogController.blacklight_config = Blacklight::Configuration.new
     CatalogController.configure_blacklight do |config|
-      config.add_facet_field 'pub_date_sort', :range => true
+      config.add_facet_field 'pub_date_sort', :label => "Publication Year", :range => true
       config.default_solr_params[:'facet.field'] = config.facet_fields.keys
     end
 
@@ -29,6 +29,8 @@ describe "Blacklight Range Limit" do
     click_link 'View distribution'
     click_link '1941 to 1944'
 
+    page.should have_selector ".document"
     page.should have_content "1941 to 1944 (1) [remove]"
+    page.should have_selector ".constraint .filterName", :text => "Publication Year" 
   end
 end


### PR DESCRIPTION
...partials are displayed when the range limit facet is the only thing selected; fixes #5
