### PR TITLE
Adds accessible labels to range limit text fields

### DIFF
--- a/app/helpers/range_limit_helper.rb
+++ b/app/helpers/range_limit_helper.rb
@@ -2,12 +2,14 @@
 module RangeLimitHelper
 
   # type is 'begin' or 'end'
-  def render_range_input(solr_field, type)
+  def render_range_input(solr_field, type, input_label = nil)
     type = type.to_s
-    
+
     default = params["range"][solr_field][type] if params["range"] && params["range"][solr_field] && params["range"][solr_field][type]
-    
-    text_field_tag("range[#{solr_field}][#{type}]", default, :maxlength=>4, :class => "form-control range_#{type}")
+
+    html = label_tag("range[#{solr_field}][#{type}]", input_label, class: 'sr-only') if input_label.present?
+    html ||= ''.html_safe
+    html += text_field_tag("range[#{solr_field}][#{type}]", default, :maxlength=>4, :class => "form-control range_#{type}")
   end
 
   # type is 'min' or 'max'
@@ -88,8 +90,8 @@ module RangeLimitHelper
     my_params.delete("range_field")
     my_params.delete("range_start")
     my_params.delete("range_end")
-    
+
     return my_params
   end
-  
+
 end

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -1,6 +1,10 @@
 <%- # requires solr_config local passed in
 
-  field_config = range_config(solr_field)
+  field_config = range_config(solr_field)  
+  label = blacklight_config.facet_fields[solr_field].label
+  
+  input_label_range_begin = field_config[:input_label_range_begin] || t("blacklight.range_limit.range_begin", field_label: label)
+  input_label_range_end   = field_config[:input_label_range_end] || t("blacklight.range_limit.range_end", field_label: label)
 -%>
 
 <div class="limit_content range_limit">  
@@ -35,7 +39,7 @@
         <%= hidden_field_tag("search_field", "dummy_range") %>
       <% end %>
       
-      <%= render_range_input(solr_field, :begin) %> – <%= render_range_input(solr_field, :end) %>
+      <%= render_range_input(solr_field, :begin, input_label_range_begin) %> – <%= render_range_input(solr_field, :end, input_label_range_end) %>
       <%= submit_tag 'Limit', :class=>'submit btn btn-default' %>
     
     <% end %>

--- a/config/locales/blacklight_range_limit.en.yml
+++ b/config/locales/blacklight_range_limit.en.yml
@@ -1,0 +1,5 @@
+en:
+  blacklight:
+    range_limit:
+      range_begin: "%{field_label} range begin"
+      range_end: "%{field_label} range end"

--- a/spec/features/blacklight_range_limit_spec.rb
+++ b/spec/features/blacklight_range_limit_spec.rb
@@ -4,16 +4,17 @@ describe "Blacklight Range Limit" do
   before do
     CatalogController.blacklight_config = Blacklight::Configuration.new
     CatalogController.configure_blacklight do |config|
-      config.add_facet_field 'pub_date_sort', :range => true
+      config.add_facet_field 'pub_date_sort', :label => 'Publication Date Sort', :range => true
       config.default_solr_params[:'facet.field'] = config.facet_fields.keys
     end
-
   end
 
   it "should show the range limit facet" do
     visit '/catalog'
     page.should have_selector 'input.range_begin'
     page.should have_selector 'input.range_end'
+    page.should have_selector 'label.sr-only[for="range_pub_date_sort_begin"]', :text => 'Publication Date Sort range begin'
+    page.should have_selector 'label.sr-only[for="range_pub_date_sort_end"]', :text => 'Publication Date Sort range end'
   end
 
   it "should provide distribution information" do
@@ -31,4 +32,24 @@ describe "Blacklight Range Limit" do
 
     page.should have_content "1941 to 1944 [remove] 1"
   end
+end
+
+describe "Blacklight Range Limit with configured input labels" do
+  before do
+    CatalogController.blacklight_config = Blacklight::Configuration.new
+    CatalogController.configure_blacklight do |config|
+      config.add_facet_field 'pub_date_sort', :range => {
+        :input_label_range_begin => 'from publication date',
+        :input_label_range_end => 'to publication date'
+      }
+      config.default_solr_params[:'facet.field'] = config.facet_fields.keys
+    end  
+  end    
+  
+  it "should show the range limit facet" do
+    visit '/catalog'
+    page.should have_selector 'label.sr-only[for="range_pub_date_sort_begin"]', :text => 'from publication date'
+    page.should have_selector 'label.sr-only[for="range_pub_date_sort_end"]', :text => 'to publication date'
+  end
+
 end

--- a/spec/helpers/blacklight_range_limit_helper_spec.rb
+++ b/spec/helpers/blacklight_range_limit_helper_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe "Blacklight Range Limit Helper" do
+
+  it "should render range text fields with/without labels" do 
+    expect(helper.render_range_input('pub_date', 'begin')).to match /^<input class=\"form-control range_begin\" id=\"range_pub_date_begin\" maxlength=\"4\"/
+    expect(helper.render_range_input('pub_date', 'begin', 'from pub date')).to match /^<label class=\"sr-only\" for=\"range_pub_date_begin\">from pub date<\/label>/
+  end
+
+end


### PR DESCRIPTION
- Adds a `label` param to `render_range_input()` helper method 
- When a label text is provided, an accessible, hidden `'.sr-only'` `<label>` is prepended to text field HTML

``` ruby
render_range_input("pub_year_tisim", :begin, "from year")
```

returns 

``` html
<label class="sr-only" for="range_pub_year_tisim_begin">from year</label>
<input class="form-control range_begin" id="range_pub_year_tisim_begin" maxlength="4" name="range[pub_year_tisim][begin]" type="text" />
```
