### PR TITLE
Allow for zero

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,6 +40,7 @@ namespace :test do
     within_test_app do
       ENV['RAILS_ENV'] ||= 'test'
       system "rake blacklight:solr:seed"
+      system "rake blacklight_range_limit:seed"
     end
   end
 

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -10,7 +10,7 @@ $(".range_limit .profile .range.slider_js").each(function() {
    var min = boundaries[0];
    var max = boundaries[1];
 
-   if (min && max) {
+   if (isInt(min) && isInt(max)) {
      $(this).contents().wrapAll('<div style="display:none" />');
      
      var range_element = $(this);
@@ -46,7 +46,6 @@ $(".range_limit .profile .range.slider_js").each(function() {
      }
    }
 
-        
   begin_el.val(min);
   end_el.val(max);
         
@@ -110,6 +109,13 @@ function min_max(range_element) {
    }
    
    return [min, max]
+}
+
+
+// Check to see if a value is an Integer
+// see: http://stackoverflow.com/questions/3885817/how-to-check-if-a-number-is-float-or-integer
+function isInt(n) {
+  return n % 1 === 0;
 }
 
 });

--- a/lib/generators/blacklight_range_limit/blacklight_range_limit_generator.rb
+++ b/lib/generators/blacklight_range_limit/blacklight_range_limit_generator.rb
@@ -7,5 +7,4 @@ class BlacklightRangeLimitGenerator < Rails::Generators::Base
   def copy_public_assets
     BlacklightRangeLimit::AssetsGenerator.start
   end
-
 end

--- a/lib/tasks/blacklight_range_limit.rake
+++ b/lib/tasks/blacklight_range_limit.rake
@@ -1,0 +1,10 @@
+require 'rails/generators'
+
+namespace :blacklight_range_limit do
+  desc 'Add in additional Solr docs'
+  task seed: :environment do
+    docs = Dir['spec/fixtures/solr_documents/*.yml'].map { |f| YAML.load File.read(f) }.flatten
+    Blacklight.solr.add docs
+    Blacklight.solr.commit
+  end
+end

--- a/spec/features/blacklight_range_limit_spec.rb
+++ b/spec/features/blacklight_range_limit_spec.rb
@@ -1,16 +1,9 @@
 require 'spec_helper'
 
 describe "Blacklight Range Limit" do
-  before do
-    CatalogController.blacklight_config = Blacklight::Configuration.new
-    CatalogController.configure_blacklight do |config|
-      config.add_facet_field 'pub_date_sort', :label => 'Publication Date Sort', :range => true
-      config.default_solr_params[:'facet.field'] = config.facet_fields.keys
-    end
-  end
 
   it "should show the range limit facet" do
-    visit '/catalog'
+    visit catalog_index_path
     page.should have_selector 'input.range_begin'
     page.should have_selector 'input.range_end'
     page.should have_selector 'label.sr-only[for="range_pub_date_sort_begin"]', :text => 'Publication Date Sort range begin'
@@ -19,19 +12,19 @@ describe "Blacklight Range Limit" do
   end
 
   it "should provide distribution information" do
-    visit '/catalog'
+    visit catalog_index_path
     click_link 'View distribution'
 
-    page.should have_content("1941 to 1944 1")
-    page.should have_content("2005 to 2008 7")
+    page.should have_content("1500 to 1599 0")
+    page.should have_content("2000 to 2008 12")
   end
 
   it "should limit appropriately" do
-    visit '/catalog'
+    visit catalog_index_path
     click_link 'View distribution'
-    click_link '1941 to 1944'
+    click_link '2000 to 2008'
 
-    page.should have_content "1941 to 1944 [remove] 1"
+    page.should have_content "2000 to 2008 [remove] 12"
   end
 end
 

--- a/spec/fixtures/solr_documents/zero_year.yml
+++ b/spec/fixtures/solr_documents/zero_year.yml
@@ -1,0 +1,3 @@
+id: 'zero_doc_id'
+title_display: 'Zero year doc'
+pub_date: 1000

--- a/spec/helpers/blacklight_range_limit_helper_spec.rb
+++ b/spec/helpers/blacklight_range_limit_helper_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "Blacklight Range Limit Helper" do
 
   it "should render range text fields with/without labels" do 
-    expect(helper.render_range_input('pub_date', 'begin')).to match /^<input class=\"form-control range_begin\" id=\"range_pub_date_begin\" maxlength=\"4\"/
+    expect(helper.render_range_input('pub_date', 'begin')).to match /^<input type=\"text\" class=\"form-control range_begin\" id=\"range_pub_date_begin\" maxlength=\"4\"/
     expect(helper.render_range_input('pub_date', 'begin', 'from pub date')).to match /^<label class=\"sr-only\" for=\"range_pub_date_begin\">from pub date<\/label>/
   end
 

--- a/spec/helpers/blacklight_range_limit_helper_spec.rb
+++ b/spec/helpers/blacklight_range_limit_helper_spec.rb
@@ -2,9 +2,11 @@ require "spec_helper"
 
 describe "Blacklight Range Limit Helper" do
 
-  it "should render range text fields with/without labels" do 
-    expect(helper.render_range_input('pub_date', 'begin')).to match /^<input type=\"text\" class=\"form-control range_begin\" id=\"range_pub_date_begin\" maxlength=\"4\"/
-    expect(helper.render_range_input('pub_date', 'begin', 'from pub date')).to match /^<label class=\"sr-only\" for=\"range_pub_date_begin\">from pub date<\/label>/
+  it "should render range text fields with/without labels" do
+    begin_html = Capybara.string(helper.render_range_input('pub_date', 'begin'))
+    begin_from_pub_html = Capybara.string(helper.render_range_input('pub_date', 'begin', 'from pub date'))
+    expect(begin_html).to have_css 'input.form-control.range_begin#range_pub_date_begin'
+    expect(begin_from_pub_html).to have_css 'label.sr-only[for="range_pub_date_begin"]'
   end
 
 end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -19,4 +19,15 @@ class TestAppGenerator < Rails::Generators::Base
 
     generate 'blacklight_range_limit'
   end
+
+  def fixtures
+    FileUtils.mkdir_p 'spec/fixtures/solr_documents'
+    directory 'solr_documents', 'spec/fixtures/solr_documents'
+  end
+
+  def inject_into_catalog_controller
+    inject_into_file 'app/controllers/catalog_controller.rb', after: "config.add_facet_field 'example_pivot_field', :label => 'Pivot Field', :pivot => ['format', 'language_facet']" do
+      "\n    config.add_facet_field 'pub_date_sort', :label => 'Publication Date Sort', :range => true"
+    end
+  end
 end

--- a/spec/test_app_templates/solr_documents
+++ b/spec/test_app_templates/solr_documents
@@ -1,0 +1,1 @@
+../fixtures/solr_documents


### PR DESCRIPTION
Previously, https://github.com/projectblacklight/blacklight_range_limit/compare/allow-for-zero?expand=1#diff-f17504e7a61c53d7423849464de8136aL13 was checking for the truthiness of the min and max values. This was causing an error when a value was zero. In JavaScript, zero, `0`, evaluates as falsey.

https://dorey.github.io/JavaScript-Equality-Table/

3 original tests fail when a zero value document is indexed (js errors). Added in an easy way to index testing documents for development and testing in 878a66f.

Now tests for a value being an int.