### PR TITLE
Address circular argument reference for ruby 2.2.0

### DIFF
--- a/lib/blacklight_range_limit/view_helper_override.rb
+++ b/lib/blacklight_range_limit/view_helper_override.rb
@@ -10,9 +10,9 @@
       super
     end
 
-    def has_range_limit_parameters?(params = params)
-      params[:range] && 
-        params[:range].any? do |key, v| 
+    def has_range_limit_parameters?(my_params = params)
+      my_params[:range] &&
+        my_params[:range].any? do |key, v|
           v.present? && v.respond_to?(:'[]') && 
           (v["begin"].present? || v["end"].present? || v["missing"].present?)
         end
@@ -23,8 +23,8 @@
       super || has_range_limit_parameters?
     end
 
-    def query_has_constraints?(params = params)         
-      super || has_range_limit_parameters?(params)
+    def query_has_constraints?(my_params = params)
+      super || has_range_limit_parameters?(my_params)
     end
 
     # Over-ride to recognize our custom params for range facets


### PR DESCRIPTION
More details in this ruby issue:
https://bugs.ruby-lang.org/issues/10314

Was causing the following error in a Blacklight 5.9.3 app:

```
---------------------------------
Completed 500 Internal Server Error in 594ms

ActionView::Template::Error (undefined method `[]' for nil:NilClass):
    1: <% if query_has_constraints? %>
    2: 
    3:       <div id="appliedParams" class="clearfix constraints-container">
    4:         <div class="pull-right">
  app/views/catalog/index.html.erb:26:in `_app_views_catalog_index_html_erb___2405140386047804326_70280807433900'
```


Was tipped off by this output when starting rails:
```
=> Rails 4.2.0 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
~/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/blacklight_range_limit-5.0.3/lib/blacklight_range_limit/view_helper_override.rb:13: warning: circular argument reference - params
~/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/blacklight_range_limit-5.0.3/lib/blacklight_range_limit/view_helper_override.rb:26: warning: circular argument reference - params
```