### PR TITLE
Move #add_range_limit_params into Blacklight::Solr::SearchBuilder

### DIFF
--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -2,6 +2,7 @@
 
 module BlacklightRangeLimit
   autoload :ControllerOverride, 'blacklight_range_limit/controller_override'
+  autoload :SearchBuilderOverride, 'blacklight_range_limit/search_builder_override'
   autoload :ViewHelperOverride, 'blacklight_range_limit/view_helper_override'
   autoload :RouteSets, 'blacklight_range_limit/route_sets'
 
@@ -22,8 +23,12 @@ module BlacklightRangeLimit
   def self.omit_inject ; @omit_inject ; end
   
   def self.inject!
-    unless omit_inject[:controller_mixin]
+      unless omit_inject[:controller_mixin]
         CatalogController.send(:include, BlacklightRangeLimit::ControllerOverride) unless Blacklight::Catalog.include?(BlacklightRangeLimit::ControllerOverride)
+      end
+
+      unless omit_inject[:search_builder_mixin]
+        Blacklight::Solr::SearchBuilder.send(:include, BlacklightRangeLimit::SearchBuilderOverride) unless Blacklight::Solr::SearchBuilder.include?(BlacklightRangeLimit::SearchBuilderOverride)
       end
 
       unless omit_inject[:view_helpers]

--- a/lib/blacklight_range_limit/controller_override.rb
+++ b/lib/blacklight_range_limit/controller_override.rb
@@ -8,11 +8,8 @@ module BlacklightRangeLimit
     extend ActiveSupport::Concern
   
     included do
-      solr_search_params_logic << :add_range_limit_params
       helper_method :range_config
-  
-      
-      
+
       unless BlacklightRangeLimit.omit_inject[:view_helpers]
         helper BlacklightRangeLimit::ViewHelperOverride
         helper RangeLimitHelper
@@ -48,52 +45,6 @@ module BlacklightRangeLimit
       render('blacklight_range_limit/range_segments', :locals => {:solr_field => solr_field}, :layout => !request.xhr?)
     end
     
-    # Method added to solr_search_params_logic to fetch
-    # proper things for date ranges. 
-    def add_range_limit_params(solr_params, req_params)
-       ranged_facet_configs = 
-         blacklight_config.facet_fields.select { |key, config| config.range } 
-       # In ruby 1.8, hash.select returns an array of pairs, in ruby 1.9
-       # it returns a hash. Turn it into a hash either way.  
-       ranged_facet_configs = Hash[ ranged_facet_configs ] unless ranged_facet_configs.kind_of?(Hash)
-       
-       ranged_facet_configs.each_pair do |solr_field, config|
-        solr_params["stats"] = "true"
-        solr_params["stats.field"] ||= []
-        solr_params["stats.field"] << solr_field    
-      
-        hash =  req_params["range"] && req_params["range"][solr_field] ?
-          req_params["range"][solr_field] :
-          {}
-          
-        if !hash["missing"].blank?
-          # missing specified in request params
-          solr_params[:fq] ||= []
-          solr_params[:fq] << "-#{solr_field}:[* TO *]"
-          
-        elsif !(hash["begin"].blank? && hash["end"].blank?)
-          # specified in request params, begin and/or end, might just have one
-          start = hash["begin"].blank? ? "*" : hash["begin"]
-          finish = hash["end"].blank? ? "*" : hash["end"]
-  
-          solr_params[:fq] ||= []
-          solr_params[:fq] << "#{solr_field}: [#{start} TO #{finish}]"
-          
-          if (config.segments != false && start != "*" && finish != "*")
-            # Add in our calculated segments, can only do with both boundaries.
-            add_range_segments_to_solr!(solr_params, solr_field, start.to_i, finish.to_i)
-          end
-          
-        elsif (config.segments != false &&
-               boundaries = config.assumed_boundaries)
-          # assumed_boundaries in config
-          add_range_segments_to_solr!(solr_params, solr_field, boundaries[0], boundaries[1])
-        end
-      end
-      
-      return solr_params
-    end
-  
     # Returns range config hash for named solr field. Returns false
     # if not configured. Returns hash even if configured to 'true'
     # for consistency. 

--- a/lib/blacklight_range_limit/search_builder_override.rb
+++ b/lib/blacklight_range_limit/search_builder_override.rb
@@ -1,0 +1,53 @@
+module BlacklightRangeLimit
+  module SearchBuilderOverride
+    include SegmentCalculation
+
+    included do
+      default_processor_chain << :add_range_limit_params
+    end
+
+    # Method added to solr_search_params_logic to fetch
+    # proper things for date ranges.
+    def add_range_limit_params(solr_params)
+      ranged_facet_configs =
+        blacklight_config.facet_fields.select { |key, config| config.range }
+      # In ruby 1.8, hash.select returns an array of pairs, in ruby 1.9
+      # it returns a hash. Turn it into a hash either way.
+      ranged_facet_configs = Hash[ranged_facet_configs] unless ranged_facet_configs.kind_of?(Hash)
+
+      ranged_facet_configs.each_pair do |solr_field, config|
+        solr_params["stats"] = "true"
+        solr_params["stats.field"] ||= []
+        solr_params["stats.field"] << solr_field
+
+        hash =  blacklight_params["range"] && blacklight_params["range"][solr_field] ?
+          blacklight_params["range"][solr_field] :
+          {}
+
+        if !hash["missing"].blank?
+          # missing specified in request params
+          solr_params[:fq] ||= []
+          solr_params[:fq] << "-#{solr_field}:[* TO *]"
+
+        elsif !(hash["begin"].blank? && hash["end"].blank?)
+          # specified in request params, begin and/or end, might just have one
+          start = hash["begin"].blank? ? "*" : hash["begin"]
+          finish = hash["end"].blank? ? "*" : hash["end"]
+
+          solr_params[:fq] ||= []
+          solr_params[:fq] << "#{solr_field}: [#{start} TO #{finish}]"
+
+          if (config.segments != false && start != "*" && finish != "*")
+            # Add in our calculated segments, can only do with both boundaries.
+            add_range_segments_to_solr!(solr_params, solr_field, start.to_i, finish.to_i)
+          end
+
+        elsif (config.segments != false &&
+               boundaries = config.assumed_boundaries)
+          # assumed_boundaries in config
+          add_range_segments_to_solr!(solr_params, solr_field, boundaries[0], boundaries[1])
+        end
+      end
+    end
+  end
+end

--- a/lib/blacklight_range_limit/search_builder_override.rb
+++ b/lib/blacklight_range_limit/search_builder_override.rb
@@ -1,6 +1,7 @@
 module BlacklightRangeLimit
   module SearchBuilderOverride
     include SegmentCalculation
+    extend ActiveSupport::Concern
 
     included do
       default_processor_chain << :add_range_limit_params


### PR DESCRIPTION
This moves the `add_range_limit_params` processor out of the controller and into `Blacklight::Solr::SearchBuilder`, following the move of search builder logic into its `Blacklight::SearchBuilder`.

This would however make blacklight_range_limit depend on blacklight version > 5.10.0, so the gemspec should be updated if this is accepted.