### PR TITLE
Requires BL 5.15+ and runs without deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,16 @@ sudo: false
 rvm:
   - 2.2.2
 
+before_install:
+  - gem install bundler
+
+env:
+ - "RAILS_VERSION=4.2.3"
+
 notifications:
   irc: "irc.freenode.org#blacklight"
   email:
       - blacklight-commits@googlegroups.com
+
+global_env:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.2.2
 
 notifications:
   irc: "irc.freenode.org#blacklight"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,12 @@ notifications:
   email: false
 
 language: ruby
-cache: bundler
 sudo: false
 rvm:
   - 2.2.2
 
 before_install:
   - gem install bundler
-
-env:
- - "RAILS_VERSION=4.2.3"
 
 notifications:
   irc: "irc.freenode.org#blacklight"

--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,10 @@ else
     gem 'sass-rails', "< 5.0"
   end
 end
+
+# I'm sorry, this is harsh and I think ought to be done some other way with
+# engine_cart, but I don't understand how or what's going on, and this
+# is all I could to avoid:
+# undefined method `type' for .focus:Sass::Selector::Class
+#         (in .../blacklight_range_limit/spec/internal/app/assets/stylesheets/blacklight.css.scss)
+gem 'sass', "~> 3.4"

--- a/blacklight_range_limit.gemspec
+++ b/blacklight_range_limit.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.0", "< 5.0"
   s.add_dependency "jquery-rails" # our JS needs jquery_rails  
-  s.add_dependency "blacklight", "~> 5.14"
+  s.add_dependency "blacklight", "~> 5.15"
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rspec-rails"

--- a/blacklight_range_limit.gemspec
+++ b/blacklight_range_limit.gemspec
@@ -18,10 +18,8 @@ Gem::Specification.new do |s|
   s.license     = "Apache 2.0"
 
   s.add_dependency "rails", ">= 3.0", "< 5.0"
-  s.add_dependency "jquery-rails" # our JS needs jquery_rails
-  # for blacklight, we want to allow 5.0.0.preX, as well as all 5.x.y, 
-  # but not 6. can't seem to make it do so other than this:
-  s.add_dependency "blacklight", ">= 5.0.0.pre4", "< 6"
+  s.add_dependency "jquery-rails" # our JS needs jquery_rails  
+  s.add_dependency "blacklight", "~> 5.14"
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rspec-rails"

--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -1,9 +1,10 @@
 # BlacklightRangeLimit
 
 module BlacklightRangeLimit
-  autoload :ControllerOverride, 'blacklight_range_limit/controller_override'
-  autoload :ViewHelperOverride, 'blacklight_range_limit/view_helper_override'
-  autoload :RouteSets, 'blacklight_range_limit/route_sets'
+  require 'blacklight_range_limit/range_limit_builder'
+  require 'blacklight_range_limit/controller_override'
+  require 'blacklight_range_limit/view_helper_override'
+  require 'blacklight_range_limit/route_sets'
 
   require 'blacklight_range_limit/version'
   require 'blacklight_range_limit/engine'
@@ -50,6 +51,24 @@ module BlacklightRangeLimit
   # Add element to array only if it's not already there
   def self.safe_arr_add(array, element)
     array << element unless array.include?(element)
+  end
+
+  # Convenience method for returning range config hash from
+  # blacklight config, for a specific solr field, in a normalized
+  # way. 
+  #
+  # Returns false if range limiting not configured. 
+  # Returns hash even if configured to 'true'
+  # for consistency. 
+  def self.range_config(blacklight_config, solr_field)
+    field = blacklight_config.facet_fields[solr_field.to_s]
+
+    return false unless field.range
+
+    config = field.range
+    config = {} if config === true
+
+    config
   end
   
 end

--- a/lib/blacklight_range_limit/controller_override.rb
+++ b/lib/blacklight_range_limit/controller_override.rb
@@ -4,18 +4,24 @@
 require 'blacklight_range_limit/segment_calculation'
 module BlacklightRangeLimit
   module ControllerOverride
-    include SegmentCalculation
     extend ActiveSupport::Concern
   
-    included do
-      solr_search_params_logic << :add_range_limit_params
-      helper_method :range_config
-  
-      
-      
+    included do        
       unless BlacklightRangeLimit.omit_inject[:view_helpers]
         helper BlacklightRangeLimit::ViewHelperOverride
         helper RangeLimitHelper
+      end
+
+      if self.respond_to? :search_params_logic
+        search_params_logic << :add_range_limit_params
+      end
+      if self.blacklight_config.search_builder_class
+        unless self.blacklight_config.search_builder_class.include?(BlacklightRangeLimit::RangeLimitBuilder)
+          self.blacklight_config.search_builder_class.send(:include,  
+              BlacklightRangeLimit::RangeLimitBuilder  
+          ) 
+          self.blacklight_config.search_builder_class.default_processor_chain << :add_range_limit_params
+        end
       end
     end
   
@@ -24,88 +30,26 @@ module BlacklightRangeLimit
     # Used when we need a second Solr query to get range facets, after the
     # first found min/max from result set. 
     def range_limit
-      solr_field = params[:range_field] # what field to fetch for
-      start = params[:range_start].to_i
-      finish = params[:range_end].to_i
-      
-      solr_params = solr_search_params(params)
-  
-      # Remove all field faceting for efficiency, we won't be using it.
-      solr_params.delete("facet.field")
-      solr_params.delete("facet.field".to_sym)
-      
-      add_range_segments_to_solr!(solr_params, solr_field, start, finish )
-      # We don't need any actual rows or facets, we're just going to look
-      # at the facet.query's
-      solr_params[:rows] = 0
-      solr_params[:facets] = nil
-      solr_params[:qt] ||= blacklight_config.qt
-      # Not really any good way to turn off facet.field's from the solr default,
-      # no big deal it should be well-cached at this point.
+      # We need to swap out the add_range_limit_params search param filter,
+      # and instead add in our fetch_specific_range_limit filter,
+      # to fetch only the range limit segments for only specific
+      # field (with start/end params) mentioned in query params
+      # range_field, range_start, and range_end
 
-      @response = Blacklight.default_index.connection.get( blacklight_config.solr_path, :params => solr_params )
-
-      render('blacklight_range_limit/range_segments', :locals => {:solr_field => solr_field}, :layout => !request.xhr?)
-    end
-    
-    # Method added to solr_search_params_logic to fetch
-    # proper things for date ranges. 
-    def add_range_limit_params(solr_params, req_params)
-       ranged_facet_configs = 
-         blacklight_config.facet_fields.select { |key, config| config.range } 
-       # In ruby 1.8, hash.select returns an array of pairs, in ruby 1.9
-       # it returns a hash. Turn it into a hash either way.  
-       ranged_facet_configs = Hash[ ranged_facet_configs ] unless ranged_facet_configs.kind_of?(Hash)
-       
-       ranged_facet_configs.each_pair do |solr_field, config|
-        solr_params["stats"] = "true"
-        solr_params["stats.field"] ||= []
-        solr_params["stats.field"] << solr_field    
-      
-        hash =  req_params["range"] && req_params["range"][solr_field] ?
-          req_params["range"][solr_field] :
-          {}
-          
-        if !hash["missing"].blank?
-          # missing specified in request params
-          solr_params[:fq] ||= []
-          solr_params[:fq] << "-#{solr_field}:[* TO *]"
-          
-        elsif !(hash["begin"].blank? && hash["end"].blank?)
-          # specified in request params, begin and/or end, might just have one
-          start = hash["begin"].blank? ? "*" : hash["begin"]
-          finish = hash["end"].blank? ? "*" : hash["end"]
-  
-          solr_params[:fq] ||= []
-          solr_params[:fq] << "#{solr_field}: [#{start} TO #{finish}]"
-          
-          if (config.segments != false && start != "*" && finish != "*")
-            # Add in our calculated segments, can only do with both boundaries.
-            add_range_segments_to_solr!(solr_params, solr_field, start.to_i, finish.to_i)
-          end
-          
-        elsif (config.segments != false &&
-               boundaries = config.assumed_boundaries)
-          # assumed_boundaries in config
-          add_range_segments_to_solr!(solr_params, solr_field, boundaries[0], boundaries[1])
-        end
+      # This rather complicated to do in current state of BL and the
+      # possible ways the app is working, we do our best. 
+      original_filter_list = if self.respond_to?(:search_params_logic) && self.search_params_logic != true
+        self.search_params_logic
+      else
+        self.blacklight_config.search_builder_class.default_processor_chain
       end
-      
-      return solr_params
-    end
-  
-    # Returns range config hash for named solr field. Returns false
-    # if not configured. Returns hash even if configured to 'true'
-    # for consistency. 
-    def range_config(solr_field)
-      field = blacklight_config.facet_fields[solr_field.to_s]
 
-      return false unless field.range
+      filter_list = original_filter_list - [:add_range_limit_params]
+      filter_list += [:fetch_specific_range_limit]
 
-      config = field.range
-      config = {} if config === true
+      @response, _ = search_results(params, filter_list)
 
-      config
+      render('blacklight_range_limit/range_segments', :locals => {:solr_field => params[:range_field]}, :layout => !request.xhr?)
     end
   end
 end

--- a/lib/blacklight_range_limit/controller_override.rb
+++ b/lib/blacklight_range_limit/controller_override.rb
@@ -36,18 +36,9 @@ module BlacklightRangeLimit
       # field (with start/end params) mentioned in query params
       # range_field, range_start, and range_end
 
-      # This rather complicated to do in current state of BL and the
-      # possible ways the app is working, we do our best. 
-      original_filter_list = if self.respond_to?(:search_params_logic) && self.search_params_logic != true
-        self.search_params_logic
-      else
-        self.blacklight_config.search_builder_class.default_processor_chain
+      @response, _ = search_results(params, search_params_logic) do |search_builder|
+        search_builder.except(:add_range_limit_params).append(:fetch_specific_range_limit)
       end
-
-      filter_list = original_filter_list - [:add_range_limit_params]
-      filter_list += [:fetch_specific_range_limit]
-
-      @response, _ = search_results(params, filter_list)
 
       render('blacklight_range_limit/range_segments', :locals => {:solr_field => params[:range_field]}, :layout => !request.xhr?)
     end

--- a/lib/blacklight_range_limit/range_limit_builder.rb
+++ b/lib/blacklight_range_limit/range_limit_builder.rb
@@ -1,0 +1,83 @@
+require 'blacklight_range_limit/segment_calculation'
+
+module BlacklightRangeLimit
+  module RangeLimitBuilder
+    include BlacklightRangeLimit::SegmentCalculation
+
+    # Method added to solr_search_params_logic to fetch
+    # proper things for date ranges. This should be added in by default to standard
+    # processing chain. 
+    def add_range_limit_params(solr_params)
+       ranged_facet_configs = 
+         blacklight_config.facet_fields.select { |key, config| config.range } 
+       # In ruby 1.8, hash.select returns an array of pairs, in ruby 1.9
+       # it returns a hash. Turn it into a hash either way.  
+       ranged_facet_configs = Hash[ ranged_facet_configs ] unless ranged_facet_configs.kind_of?(Hash)
+       
+       ranged_facet_configs.each_pair do |solr_field, config|
+        solr_params["stats"] = "true"
+        solr_params["stats.field"] ||= []
+        solr_params["stats.field"] << solr_field    
+      
+        hash =  blacklight_params["range"] && blacklight_params["range"][solr_field] ?
+          blacklight_params["range"][solr_field] :
+          {}
+          
+        if !hash["missing"].blank?
+          # missing specified in request params
+          solr_params[:fq] ||= []
+          solr_params[:fq] << "-#{solr_field}:[* TO *]"
+          
+        elsif !(hash["begin"].blank? && hash["end"].blank?)
+          # specified in request params, begin and/or end, might just have one
+          start = hash["begin"].blank? ? "*" : hash["begin"]
+          finish = hash["end"].blank? ? "*" : hash["end"]
+  
+          solr_params[:fq] ||= []
+          solr_params[:fq] << "#{solr_field}: [#{start} TO #{finish}]"
+          
+          if (config.segments != false && start != "*" && finish != "*")
+            # Add in our calculated segments, can only do with both boundaries.
+            add_range_segments_to_solr!(solr_params, solr_field, start.to_i, finish.to_i)
+          end
+          
+        elsif (config.segments != false &&
+               boundaries = config.assumed_boundaries)
+          # assumed_boundaries in config
+          add_range_segments_to_solr!(solr_params, solr_field, boundaries[0], boundaries[1])
+        end
+      end
+      
+      return solr_params
+    end
+
+
+    # Another processing method, this one is NOT included in default processing chain,
+    # it is specifically swapped in *instead of* add_range_limit_params for
+    # certain ajax requests that only want to fetch range limit segments for
+    # ONE field. 
+    #
+    # It turns off facetting and sets rows to 0 as well, only results for
+    # single specified field are needed. 
+    #
+    # Specified field and parameters are specified in incoming parameters
+    # range_field, range_start, range_end
+    def fetch_specific_range_limit(solr_params)
+      solr_field = blacklight_params[:range_field] # what field to fetch for
+      start = blacklight_params[:range_start].to_i
+      finish = blacklight_params[:range_end].to_i
+
+      add_range_segments_to_solr!(solr_params, solr_field, start, finish )
+        
+      # Remove all field faceting for efficiency, we won't be using it.
+      solr_params.delete("facet.field")
+      solr_params.delete("facet.field".to_sym)
+
+      # We don't need any actual rows either
+      solr_params[:rows] = 0      
+
+      return solr_params
+    end
+
+  end
+end

--- a/lib/blacklight_range_limit/segment_calculation.rb
+++ b/lib/blacklight_range_limit/segment_calculation.rb
@@ -12,7 +12,7 @@ module BlacklightRangeLimit
     #
     # Changes solr_params passed in. 
     def add_range_segments_to_solr!(solr_params, solr_field, min, max)
-      field_config = range_config(solr_field)    
+      field_config = BlacklightRangeLimit.range_config(blacklight_config, solr_field)    
     
       solr_params[:"facet.query"] ||= []
       
@@ -98,6 +98,8 @@ module BlacklightRangeLimit
     def floorInBase(n, base) 
        return base * (n / base).floor
     end
+
+
     
   end
 end

--- a/lib/blacklight_range_limit/view_helper_override.rb
+++ b/lib/blacklight_range_limit/view_helper_override.rb
@@ -103,6 +103,10 @@
 
       return array
     end
+
+    def range_config(solr_field)
+      BlacklightRangeLimit.range_config(blacklight_config, solr_field)
+    end
     
   end
 


### PR DESCRIPTION
I followed cbeer's lead
projectblacklight/blacklight_advanced_search@ca1b13acb165d05
for some integration. That is, a module included in CatalogController,
on inclusion will include a module in the configured SearchBuilder.
This is a bit wacky, but I wasn't sure the right safe way to do this
for all the current configuration possibilities, so just followed
cbeer's lead.

Note also at
https://github.com/projectblacklight/blacklight_range_limit/blob/bl514/lib/blacklight_range_limit/controller_override.rb#L41-L45
some contortions needed to execute a search_results intended to be
"default processor chain, but with one method removed, and another one
added", and do it in a safe way for various configurations. This may
be something BL API should support better built-in, with arguments
to SearchBuilder/CatalogController#search_results ?