### PR TITLE
Use facet_field_label for rendering facet/filter names

### DIFF
--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -1,7 +1,7 @@
 <%- # requires solr_config local passed in
 
   field_config = range_config(solr_field)  
-  label = blacklight_config.facet_fields[solr_field].label
+  label = facet_field_label(solr_field)
   
   input_label_range_begin = field_config[:input_label_range_begin] || t("blacklight.range_limit.range_begin", field_label: label)
   input_label_range_end   = field_config[:input_label_range_end] || t("blacklight.range_limit.range_end", field_label: label)

--- a/lib/blacklight_range_limit/view_helper_override.rb
+++ b/lib/blacklight_range_limit/view_helper_override.rb
@@ -48,7 +48,7 @@
 
           next unless hash["missing"] || (!hash["begin"].blank?) || (!hash["end"].blank?)
           content << render_constraint_element(
-            blacklight_config.facet_fields[solr_field].label,
+            facet_field_label(solr_field),
             range_display(solr_field, my_params),
             :escape_value => false,
             :remove => remove_range_param(solr_field, my_params)
@@ -66,7 +66,7 @@
           next unless hash["missing"] || (!hash["begin"].blank?) || (! hash["end"].blank?)        
           
           content << render_search_to_s_element(
-            blacklight_config.facet_fields[solr_field].label,
+            facet_field_label(solr_field),
             range_display(solr_field, my_params),
             :escape_value => false
           )          

--- a/spec/features/blacklight_range_limit_spec.rb
+++ b/spec/features/blacklight_range_limit_spec.rb
@@ -26,6 +26,21 @@ describe "Blacklight Range Limit" do
 
     expect(page).to have_content "2000 to 2008 [remove] 12"
   end
+
+  context 'when I18n translation is available' do
+    before do
+      I18n.backend.store_translations(:en, blacklight: {search: {fields: {facet: {pub_date_sort: 'Publication Date I18n'}}}})
+    end
+
+    it 'should render the I18n label' do
+      visit catalog_index_path
+      click_link 'View distribution'
+      click_link '2000 to 2008'
+
+      expect(page).to have_content 'Publication Date I18n'
+      expect(page).to_not have_content 'Publication Date Sort'
+    end
+  end
 end
 
 describe "Blacklight Range Limit with configured input labels" do


### PR DESCRIPTION
- Rely on facet_field_label to choose the correct label
  for the facet field when displaying its name.
- Added basic testing to assert that when I18n translation
  is available, then it is preferred over the :label option
  given when adding the facet field in the BL config.