### PR TITLE
allow range limit and advanced search to install without conflicts

### DIFF
--- a/lib/generators/blacklight_range_limit/install_generator.rb
+++ b/lib/generators/blacklight_range_limit/install_generator.rb
@@ -16,7 +16,7 @@ module BlacklightRangeLimit
 
     def install_search_builder
       path = 'app/models/search_builder.rb'
-      if File.exists? path
+      if File.exist? path
         inject_into_file path, after: /include Blacklight::Solr::SearchBuilderBehavior.*$/ do
           "\n  include BlacklightRangeLimit::RangeLimitBuilder\n"
         end
@@ -25,8 +25,20 @@ module BlacklightRangeLimit
       end
     end
 
+    # Adds range limit behavior to search history controller
     def install_search_history_controller
-     copy_file "search_history_controller.rb", "app/controllers/search_history_controller.rb"
+      path = 'app/controllers/search_history_controller.rb'
+
+      # If local copy of search history controller exists, add range limit helpers
+      if File.exist? path
+        inject_into_file path, after: /include Blacklight::SearchHistory.*$/ do
+          "\n  helper BlacklightRangeLimit::ViewHelperOverride"\
+          "\n  helper RangeLimitHelper"
+        end
+      # Otherwise copies search history controller to application
+      else
+        copy_file 'search_history_controller.rb', path
+      end
     end
 
     def install_routing_concern

--- a/lib/generators/blacklight_range_limit/templates/search_history_controller.rb
+++ b/lib/generators/blacklight_range_limit/templates/search_history_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SearchHistoryController < ApplicationController
   include Blacklight::SearchHistory
 


### PR DESCRIPTION
This change allows the blacklight_range_limit plugin to properly install when the application already has an existing search history and saved searches controller, adding the range limit behavior to the controllers rather than overwriting them. The advanced search plugin also modifies these controllers so this change makes it easier to install a blacklight application that uses both plugins.