### PR TITLE
adds compatibility for rails 5.1, closes #64

### DIFF
--- a/blacklight_range_limit.gemspec
+++ b/blacklight_range_limit.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 3.0'
   s.add_dependency 'jquery-rails' # our JS needs jquery_rails
-  s.add_dependency 'blacklight', '~> 6.0'
-  
+  s.add_dependency 'blacklight', '>= 6.0.2'
+
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'capybara'

--- a/lib/blacklight_range_limit/view_helper_override.rb
+++ b/lib/blacklight_range_limit/view_helper_override.rb
@@ -1,10 +1,10 @@
   # Meant to be applied on top of Blacklight helpers, to over-ride
   # Will add rendering of limit itself in sidebar, and of constraings
-  # display. 
+  # display.
   module BlacklightRangeLimit::ViewHelperOverride
 
 
-    
+
     def facet_partial_name(display_facet)
       return "blacklight_range_limit/range_limit_panel" if range_config(display_facet.name) and should_show_limit(display_facet.name)
       super
@@ -12,8 +12,8 @@
 
     def has_range_limit_parameters?(my_params = params)
       my_params[:range] &&
-        my_params[:range].any? do |key, v|
-          v.present? && v.respond_to?(:'[]') && 
+        my_params[:range].to_unsafe_h.any? do |key, v|
+          v.present? && v.respond_to?(:'[]') &&
           (v["begin"].present? || v["end"].present? || v["missing"].present?)
         end
     end
@@ -52,7 +52,7 @@
             range_display(solr_field, my_params),
             :escape_value => false,
             :remove => remove_range_param(solr_field, my_params)
-          )                      
+          )
         end
       end
       return content
@@ -63,14 +63,14 @@
       # add a constraint for ranges?
       unless my_params[:range].blank?
         my_params[:range].each_pair do |solr_field, hash|
-          next unless hash["missing"] || (!hash["begin"].blank?) || (! hash["end"].blank?)        
-          
+          next unless hash["missing"] || (!hash["begin"].blank?) || (! hash["end"].blank?)
+
           content << render_search_to_s_element(
             facet_field_label(solr_field),
             range_display(solr_field, my_params),
             :escape_value => false
-          )          
-        
+          )
+
         end
       end
       return content
@@ -89,7 +89,7 @@
     # Looks in the solr @response for ["facet_counts"]["facet_queries"][solr_field], for elements
     # expressed as "solr_field:[X to Y]", turns them into
     # a list of hashes with [:from, :to, :count], sorted by
-    # :from. Assumes integers for sorting purposes. 
+    # :from. Assumes integers for sorting purposes.
     def solr_range_queries_to_a(solr_field)
       return [] unless @response["facet_counts"] && @response["facet_counts"]["facet_queries"]
 
@@ -108,6 +108,5 @@
     def range_config(solr_field)
       BlacklightRangeLimit.range_config(blacklight_config, solr_field)
     end
-    
-  end
 
+  end


### PR DESCRIPTION
Converts the actioncontroller parameter object into a hash calling the `any?` method. Adds compatibility for rails 5.1, but requires at least rails version [4.2](http://api.rubyonrails.org/v4.2.0/classes/ActionController/Parameters.html#method-i-to_unsafe_h). 
Updated minimum supported Blacklight version to 6.0.2 raises the [minimum required rails version](https://github.com/projectblacklight/blacklight/blob/v6.0.2/blacklight.gemspec#L25) to 4.2.