### PR TITLE
Moves from size to length for jQuery 3.x compatibility

### DIFF
--- a/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
@@ -37,7 +37,7 @@ Blacklight.onLoad(function() {
     var container =  $(event.target).filter(".facet-content").find(".chart_js");
 
     // only if it doesn't already have a canvas, it isn't already drawn
-    if (container && container.find("canvas").size() == 0) {
+    if (container && container.find("canvas").length == 0) {
       // be willing to wait up to 1100ms for container to
       // have width -- right away on show.bs is too soon, but
       // shown.bs is later than we want, we want to start rendering

--- a/lib/blacklight_range_limit/engine.rb
+++ b/lib/blacklight_range_limit/engine.rb
@@ -1,6 +1,7 @@
 require 'blacklight'
 require 'blacklight_range_limit'
 require 'rails'
+require 'jquery-rails'
 
 module BlacklightRangeLimit
   class Engine < Rails::Engine

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -544,12 +544,6 @@
    -->
  <uniqueKey>id</uniqueKey>
 
- <!-- field for the QueryParser to use when an explicit fieldname is absent -->
- <defaultSearchField>text</defaultSearchField>
-
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
-
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->


### PR DESCRIPTION
This should be backwards compatible to jQuery 1.8 when it was
deprecated.

https://jquery.com/upgrade-guide/3.0/#breaking-change-deprecated-size-removed