### PR TITLE
remove unnecessary and detrimental tooltip require

### DIFF
--- a/app/assets/javascripts/blacklight_range_limit.js
+++ b/app/assets/javascripts/blacklight_range_limit.js
@@ -8,6 +8,4 @@
 //= require 'flot/jquery.flot.selection.js'
 //= require 'bootstrap-slider'
 
-//= require bootstrap/tooltip
-
 //= require_tree './blacklight_range_limit'


### PR DESCRIPTION
This is no longer needed, as tooltip is included by default in
Bootstrap. Including the module directly was causing an error as
Bootstrap 4 removed UMD builds.

@jkeck this should resolve the BlacklightRangeLimit based errors 