### PR TITLE
Changing to the way other deselects are treated in Blacklight 7

### DIFF
--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -14,7 +14,7 @@
         <span class="facet-label">
           <span class="selected"><%= range_display(field_name) %></span>
            <%= link_to remove_range_param(field_name), :class=>"remove", :title => t('blacklight.range_limit.remove_limit') do %>
-            <span class="glyphicon glyphicon-remove"></span>
+           <span class="remove-icon">✖</span>
             <span class="sr-only">[<%= t('blacklight.range_limit.remove_limit') %>]</span>
            <% end %>
         </span>


### PR DESCRIPTION
Otherwise the little "X" icon won't appear next to a selected date range.