### PR TITLE
Remove generated 'require tether'

### DIFF
--- a/blacklight_range_limit.gemspec
+++ b/blacklight_range_limit.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 3.0'
   s.add_dependency 'jquery-rails' # our JS needs jquery_rails
   s.add_dependency 'blacklight'
-  s.add_dependency 'tether-rails'
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-rails'

--- a/lib/blacklight_range_limit/engine.rb
+++ b/lib/blacklight_range_limit/engine.rb
@@ -2,7 +2,6 @@ require 'blacklight'
 require 'blacklight_range_limit'
 require 'rails'
 require 'jquery-rails'
-require 'tether-rails'
 
 module BlacklightRangeLimit
   class Engine < Rails::Engine

--- a/lib/generators/blacklight_range_limit/assets_generator.rb
+++ b/lib/generators/blacklight_range_limit/assets_generator.rb
@@ -41,9 +41,6 @@ module BlacklightRangeLimit
 
 }
       end
-      inject_into_file 'app/assets/javascripts/application.js', before: '// Required by Blacklight' do
-        "\n//= require tether\n"
-      end
     end
 
 


### PR DESCRIPTION
tether.js is not actually relevant to any blacklight_range_limit JS.

Earlier pre-releases of Bootstrap 4 required tether for tooltips. But even before final Bootstrap 4.0, Bootstrap tooltips were no longer using tether, using 'popper.js' instead. https://github.com/twbs/bootstrap/pull/22444

So the generated require tether (and rail gem to provide tether as a sprockets asset) are irrelevant to blacklight_range_limit.

It is not necessary to replace with a "require 'popper'":
* A standard generated blacklight app will already have a "require 'popper'" in it's application.js https://github.com/projectblacklight/blacklight/blob/55e748dd3465b9e2781d4def04b912fcbfb1b231/lib/generators/blacklight/assets_generator.rb#L20
* The failure mode for not having popper is graceful -- tooltips simply won't work, and you will get a line in JS console "Bootstrap's tooltips require Popper.js"

Closes #97