### PR TITLE
Avoid whitespace in facet-count span for 'missing' line

### DIFF
--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -79,9 +79,9 @@
               <span class="facet-label">
                 <%= link_to BlacklightRangeLimit.labels[:missing], add_range_missing(field_name) %>
               </span>
-              <span class="facet-count">
-                <%= number_with_delimiter(stats["missing"]) %>
-              </span>
+              <%# note important there be no whitespace inside facet-count to avoid
+                  bug in some versions of Blacklight (including 7.1.0.alpha) %>
+              <span class="facet-count"><%= number_with_delimiter(stats["missing"]) %></span>
             </li>
           </ul>
         <% end %>


### PR DESCRIPTION
Whitespace triggers a bug in some odd Blacklight JS that tries to calculate display size of facet-counts.

Closes #98

Also reported to Blacklight at:
https://github.com/projectblacklight/blacklight/issues/2098