### PR TITLE
have travis install bundler 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ rvm:
   - 2.3.1
 
 before_install:
-  - gem install bundler
+  # engine_cart 1.x has a hard-dependency on bundler 1.x. Until
+  # we can upgrade to engine_cart 2.x, need to make sure we have a bundler 1.x.
+  # and it's the latest bundler, so it will be used.
+  - gem install -v "~> 1.0" bundler --no-document
 
 notifications:
   irc: "irc.freenode.org#blacklight"


### PR DESCRIPTION
engine_cart 1.x has a hard dependency on bundler 1.x (rather than 2.x). Until we can upgrade to engine_cart 2.x, need to make sure bundler 1.x is being used by travis

Best would be upgrading to engine_cart 2.x, which is appropriately agnostic about which version of bundler you use. But I made some very tentative forays there, and decided it was non-trivial to do that, and I personally didn't have time for it at present. This gets us back to green so it's not a blocker for other work on blacklight_range_limit.