### PR TITLE
Tell travis to test under ruby 2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
 language: ruby
 sudo: false
 rvm:
-  - 2.3.1
+  - 2.5.5
 
 before_install:
   - gem install bundler


### PR DESCRIPTION
Was previously testing 2.3.1.  MRI 2.3 is EOL as of 2019-03-31.

Latest version of capybara seems to be refusing to run under MRI < 2.4. So was having trouble in travis. (Not sure why only some runs seemed to be having trouble).

This project was never set up for testing under multiple MRI versions (and may not really need to be), just updating to a more recent ruby seems okay?  

I choose 2.5, but can also choose 2.4, or if you think we should keep testing under 2.3... can lock to an older version of capybara?

```
Installing capybara 3.18.0
Gem::RuntimeRequirementNotMetError: capybara requires Ruby version >= 2.4.0. The
current ruby version is 2.3.1.112.
An error occurred while installing capybara (3.18.0), and Bundler
cannot continue.
Make sure that `gem install capybara -v '3.18.0' --source
'https://rubygems.org/'` succeeds before bundling.
In Gemfile:
  capybara
```