### PR TITLE
Remove unnecessary dummy_range field.

### DIFF
--- a/app/helpers/range_limit_helper.rb
+++ b/app/helpers/range_limit_helper.rb
@@ -72,11 +72,6 @@ module RangeLimitHelper
     my_params["range"][solr_field] ||= {}
     my_params["range"][solr_field]["missing"] = "true"
 
-    # Need to ensure there's a search_field to trick Blacklight
-    # into displaying results, not placeholder page. Kind of hacky,
-    # but works for now.
-    my_params["search_field"] ||= "dummy_range"
-
     my_params
   end
 

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -28,13 +28,6 @@
     <%= form_tag search_action_path, :method => :get, class: [BlacklightRangeLimit.classes[:form], "range_#{field_name}"].join(' ') do %>
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:page)) %>
 
-      <!-- we need to include a dummy search_field parameter if none exists,
-           to trick blacklight into displaying actual search results instead
-           of home page. Not a great solution, but easiest for now. -->
-      <% unless params.has_key?(:search_field) %>
-        <%= hidden_field_tag("search_field", "dummy_range") %>
-      <% end %>
-
       <%= render_range_input(field_name, :begin, input_label_range_begin, maxlength) %> – <%= render_range_input(field_name, :end, input_label_range_end, maxlength) %>
       <%= submit_tag t('blacklight.range_limit.submit_limit'), class: BlacklightRangeLimit.classes[:submit] %>
     <% end %>


### PR DESCRIPTION
Apparently nine years ago when this change was added to blacklight_range_limit,
blacklight required a search_field to be added or it would not show
results.  However this is no longer the case as one can verify by doing
a search in the demo site at https://demo.projectblacklight.org/?q=test.

Creating this dummy field is causing issues on some of the blacklight
instances when a search is made without adding search_field.

See example here:
![image](https://user-images.githubusercontent.com/444215/67702414-15e97280-f988-11e9-961b-c89b20ba14ea.png)

* https://librarysearch.temple.edu/catalog?utf8=%E2%9C%93&q=test&search_field=dummy_range&range%5Bpub_date_sort%5D%5Bbegin%5D=1504&range%5Bpub_date_sort%5D%5Bend%5D=2020&commit=Apply
* https://catalog.princeton.edu/?utf8=%E2%9C%93&q=test&search_field=dummy_range&range%5Bpub_date_start_sort%5D%5Bbegin%5D=1000&range%5Bpub_date_start_sort%5D%5Bend%5D=9999&commit=Limit

Note the "Dummy Range" label in the constraint widget.

This commit removes adding the dummy_range field when seach_field is not
defined as it is no longer required and causes issues on some current
blacklight instances.