### PR TITLE
Make this plugin more amenable to reuse in other controllers

### DIFF
--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -13,7 +13,7 @@
       <li class="selected">
         <span class="facet-label">
           <span class="selected"><%= range_display(field_name) %></span>
-          <%= link_to remove_range_param(field_name), :class=>"remove", :title => t('blacklight.range_limit.remove_limit') do %>
+          <%= link_to search_action_url(remove_range_param(field_name).except(:controller, :action)), :class=>"remove", :title => t('blacklight.range_limit.remove_limit') do %>
             <span class="remove-icon">✖</span>
             <span class="sr-only">[<%= t('blacklight.range_limit.remove_limit') %>]</span>
           <% end %>
@@ -58,7 +58,7 @@
                  <%= render(:partial => "blacklight_range_limit/range_segments", :locals => {:solr_field => field_name}) %>
 
               <% else %>
-                <%= link_to('View distribution', main_app.url_for(search_state.to_h.merge(action: 'range_limit', range_field: field_name, range_start: min, range_end: max)), :class => "load_distribution") %>
+                <%= link_to('View distribution', search_action_url(search_state.to_h.merge(action: 'range_limit', range_field: field_name, range_start: min, range_end: max)), :class => "load_distribution") %>
               <% end %>
             </div>
           <% end %>
@@ -68,7 +68,7 @@
           <ul class="missing list-unstyled facet-values subsection">
             <li>
               <span class="facet-label">
-                <%= link_to BlacklightRangeLimit.labels[:missing], add_range_missing(field_name) %>
+                <%= link_to BlacklightRangeLimit.labels[:missing], search_action_url(add_range_missing(field_name).except(:controller, :action)) %>
               </span>
               <%# note important there be no whitespace inside facet-count to avoid
                   bug in some versions of Blacklight (including 7.1.0.alpha) %>

--- a/app/views/blacklight_range_limit/_range_segments.html.erb
+++ b/app/views/blacklight_range_limit/_range_segments.html.erb
@@ -6,12 +6,12 @@
     <li>
         <span class="facet-label">
             <%= link_to(
-              content_tag("span", facet_display_value(solr_field, hash[:from]), :class => "from") + 
-                " to " + 
-                content_tag("span", facet_display_value(solr_field, hash[:to]), :class => "to"), 
-                add_range(solr_field, hash[:from], hash[:to]).merge(:action => "index"),
+              content_tag("span", facet_display_value(solr_field, hash[:from]), :class => "from") +
+                " to " +
+                content_tag("span", facet_display_value(solr_field, hash[:to]), :class => "to"),
+                search_action_url(add_range(solr_field, hash[:from], hash[:to]).except(:controller, :action)),
                 :class => "facet_select"
-              ) %> 
+              ) %>
         </span>
         <%= render_facet_count hash[:count], classes: ['count'] %>
     </li>

--- a/lib/blacklight_range_limit/controller_override.rb
+++ b/lib/blacklight_range_limit/controller_override.rb
@@ -9,6 +9,7 @@ module BlacklightRangeLimit
     included do
       helper BlacklightRangeLimit::ViewHelperOverride
       helper RangeLimitHelper
+      helper_method :has_range_limit_parameters?
     end
 
     # Action method of our own!
@@ -26,6 +27,19 @@ module BlacklightRangeLimit
         search_builder.except(:add_range_limit_params).append(:fetch_specific_range_limit)
       end
       render('blacklight_range_limit/range_segments', :locals => {:solr_field => params[:range_field]}, :layout => !request.xhr?)
+    end
+
+    # over-ride, call super, but make sure our range limits count too
+    def has_search_parameters?
+      super || has_range_limit_parameters?
+    end
+
+    def has_range_limit_parameters?(my_params = params)
+      my_params[:range] &&
+        my_params[:range].to_unsafe_h.any? do |key, v|
+          v.present? && v.respond_to?(:'[]') &&
+          (v["begin"].present? || v["end"].present? || v["missing"].present?)
+        end
     end
   end
 end

--- a/lib/blacklight_range_limit/view_helper_override.rb
+++ b/lib/blacklight_range_limit/view_helper_override.rb
@@ -11,19 +11,6 @@
       super
     end
 
-    def has_range_limit_parameters?(my_params = params)
-      my_params[:range] &&
-        my_params[:range].to_unsafe_h.any? do |key, v|
-          v.present? && v.respond_to?(:'[]') &&
-          (v["begin"].present? || v["end"].present? || v["missing"].present?)
-        end
-    end
-
-    # over-ride, call super, but make sure our range limits count too
-    def has_search_parameters?
-      super || has_range_limit_parameters?
-    end
-
     def query_has_constraints?(my_params = params)
       super || has_range_limit_parameters?(my_params)
     end


### PR DESCRIPTION
In particular, these changes should make it possible to integrate the range limit widget into Spotlight home pages (which are not a catalog controller-style controller).

Related to https://github.com/sul-dlss/exhibits/issues/1356