### PR TITLE
Remove the Unknown link in the modal display

### DIFF
--- a/app/assets/stylesheets/blacklight_range_limit/blacklight_range_limit.css
+++ b/app/assets/stylesheets/blacklight_range_limit/blacklight_range_limit.css
@@ -3,6 +3,11 @@ form.range_limit {
   line-height: 3;
 }
 
+.range_limit .range-limit-input-group {
+  max-width: 350px;
+  width: 100% !important;
+}
+
 .range_limit input.range_begin, .range_limit input.range_end {
   display: inline-block;
   width: 4.5em;

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -59,7 +59,7 @@
     <%= form_tag search_action_path, :method => :get, class: [BlacklightRangeLimit.classes[:form], "range_#{field_name} d-flex justify-content-center"].join(' ') do %>
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:page)) %>
       <%= content_tag :label, t('blacklight.range_limit.date_range_label'), class: 'range_limit_label sr-only' %>
-      <div class="input-group input-group-sm mb-3 range-limit-input-group">
+      <div class="input-group input-group-sm mb-3 flex-nowrap range-limit-input-group">
         <%= render_range_input(field_name, :begin, input_label_range_begin, maxlength) %>
         <%= render_range_input(field_name, :end, input_label_range_end, maxlength) %>
         <div class="input-group-append">

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -56,10 +56,10 @@
         <% end %>
     </div>
 
-    <%= form_tag search_action_path, :method => :get, class: [BlacklightRangeLimit.classes[:form], "range_#{field_name}"].join(' ') do %>
+    <%= form_tag search_action_path, :method => :get, class: [BlacklightRangeLimit.classes[:form], "range_#{field_name} d-flex justify-content-center"].join(' ') do %>
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:page)) %>
       <%= content_tag :label, t('blacklight.range_limit.date_range_label'), class: 'range_limit_label sr-only' %>
-      <div class="input-group input-group-sm w-100 mb-3">
+      <div class="input-group input-group-sm mb-3 range-limit-input-group">
         <%= render_range_input(field_name, :begin, input_label_range_begin, maxlength) %>
         <%= render_range_input(field_name, :end, input_label_range_end, maxlength) %>
         <div class="input-group-append">

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -73,17 +73,19 @@
         class: 'view_larger mt-1',
         data: { blacklight_modal: 'trigger' } %>
 
-    <% if (stats = stats_for_field(field_name)) && stats["missing"] > 0 %>
-      <ul class="missing list-unstyled facet-values subsection">
-        <li>
-          <span class="facet-label">
-            <%= link_to t('blacklight.range_limit.missing'), search_action_url(add_range_missing(field_name).except(:controller, :action)) %>
-          </span>
-          <%# note important there be no whitespace inside facet-count to avoid
-              bug in some versions of Blacklight (including 7.1.0.alpha) %>
-          <span class="facet-count"><%= number_with_delimiter(stats["missing"]) %></span>
-        </li>
-      </ul>
+    <% unless request.xhr? %>
+      <% if (stats = stats_for_field(field_name)) && stats["missing"] > 0 %>
+        <ul class="missing list-unstyled facet-values subsection">
+          <li>
+            <span class="facet-label">
+              <%= link_to t('blacklight.range_limit.missing'), search_action_url(add_range_missing(field_name).except(:controller, :action)) %>
+            </span>
+            <%# note important there be no whitespace inside facet-count to avoid
+                bug in some versions of Blacklight (including 7.1.0.alpha) %>
+            <span class="facet-count"><%= number_with_delimiter(stats["missing"]) %></span>
+          </li>
+        </ul>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -48,7 +48,7 @@
           alternative_title_tsim
           active_fedora_model_ssi
           title_tsim
-          author_tsimesim
+          author_tsim
           subject_tsim
           all_text_timv
         </str>

--- a/spec/features/a_javascript_spec.rb
+++ b/spec/features/a_javascript_spec.rb
@@ -20,4 +20,32 @@ describe 'JavaScript', js: true do
       expect(page).to have_css '.flot-base'
     end
   end
+
+  describe '"Unknown" link' do
+    context 'when in the facet (e.g. non-xhr)' do
+      it 'is displayed' do
+        visit search_catalog_path
+
+        click_button 'Publication Date Sort'
+
+        within 'ul.subsection.missing' do
+          expect(page).to have_link 'Unknown'
+        end
+      end
+    end
+
+    context 'when in the modal (e.g. via xhr)' do
+      it 'is not displayed' do
+        visit search_catalog_path
+
+        click_button 'Publication Date Sort'
+        sleep(1) # resize is debounced
+        click_link 'View larger »'
+
+        within '.modal-body' do
+          expect(page).not_to have_css 'ul.subsection.missing'
+        end
+      end
+    end
+  end
 end

--- a/spec/fixtures/solr_documents/unknown_year.yml
+++ b/spec/fixtures/solr_documents/unknown_year.yml
@@ -1,0 +1,2 @@
+id: 'unknown_doc_id'
+title_tsim: 'Unknown year doc'


### PR DESCRIPTION
Closes sul-dlss/dlme#770

## Small width (before)
<img width="228" alt="small-before" src="https://user-images.githubusercontent.com/96776/70267683-c7cc4980-1753-11ea-80bf-71163a69c317.png">

## Small width (after)
<img width="228" alt="small-after" src="https://user-images.githubusercontent.com/96776/70267684-c7cc4980-1753-11ea-8da3-225a021d6992.png">

## In a collapsed facet section (before)
<img width="705" alt="collapsed-facet-before" src="https://user-images.githubusercontent.com/96776/70267685-c7cc4980-1753-11ea-9e5c-0cf839f2ac3c.png">

## In a collapsed facet section (after)
<img width="703" alt="collapsed-facet-after" src="https://user-images.githubusercontent.com/96776/70267686-c7cc4980-1753-11ea-9fee-6ede33f73efb.png">

## In a modal (before)
<img width="809" alt="modal-before" src="https://user-images.githubusercontent.com/96776/70267687-c864e000-1753-11ea-8672-542802d0ae6c.png">

## In a modal (after)
<img width="810" alt="modal-after" src="https://user-images.githubusercontent.com/96776/70267688-c864e000-1753-11ea-9718-82c12882a295.png">
