### PR TITLE
Style tweaks

### DIFF
--- a/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
@@ -200,7 +200,7 @@ Blacklight.onLoad(function() {
             //xaxis: { ticks: x_ticks },
             xaxis: { tickDecimals: 0 }, // force integer ticks
             series: { lines: { fill: true, steps: true }},
-            grid: {clickable: true, hoverable: true, autoHighlight: false, margin: { left: -14, right: -12 }},
+            grid: {clickable: true, hoverable: true, autoHighlight: false, margin: { left: 0, right: 0 }},
             selection: {mode: "x"}
           }));
         }

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -21,8 +21,6 @@ $("body").on("plotDrawn.blacklight.rangeLimit", function(event) {
   if (plot && slider_el) {
       slider_el.width(plot.width());
       slider_el.css("display", "block")
-      slider_el.css('margin-right', 'auto');
-      slider_el.css('margin-left', 'auto'); 
   }
 });
 
@@ -91,8 +89,6 @@ function isInt(n) {
         if (plot && slider_el) {
           slider_el.width(plot.width());
           slider_el.css("display", "block")
-          slider_el.css('margin-right', 'auto');
-          slider_el.css('margin-left', 'auto');
         } else if (slider_el) {
           slider_el.css("width", "100%");
         }

--- a/app/assets/stylesheets/blacklight_range_limit/blacklight_range_limit.css
+++ b/app/assets/stylesheets/blacklight_range_limit/blacklight_range_limit.css
@@ -62,4 +62,6 @@ form .range_limit_label {
 
 .range_limit .chart_js {
   min-height: 80px;
+  margin-left: -12px;
+  margin-right: -14px;
 }

--- a/app/assets/stylesheets/blacklight_range_limit/blacklight_range_limit.css
+++ b/app/assets/stylesheets/blacklight_range_limit/blacklight_range_limit.css
@@ -27,7 +27,8 @@ form.range_limit {
 }
 
 .slider_js .slider-horizontal {
-  width: 100% !important;
+  margin-left: 5px;
+  margin-right: 5px;
 }
 
 .chart_js .flot-x-axis {


### PR DESCRIPTION
Fixes #131 

Before:
<img width="292" alt="Screen Shot 2019-12-16 at 10 44 59" src="https://user-images.githubusercontent.com/111218/70933611-26fe4980-1ff1-11ea-8abc-42db4233c648.png">

After:
<img width="274" alt="Screen Shot 2019-12-16 at 10 48 03" src="https://user-images.githubusercontent.com/111218/70933885-970ccf80-1ff1-11ea-8bf3-34a55a913644.png">

