### PR TITLE
Update Travis build to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: ruby
 addons:
   chrome: stable


### PR DESCRIPTION
I kicked our `master` builds for the first time in a month and we're seeing the following error:
```
    Selenium::WebDriver::Error::SessionNotCreatedError:

       session not created exception: Chrome version must be >= 67.0.3396.0

         (Driver info: chromedriver=2.41.578700 (2f1ed5f9343c13f73144538f15c00b370eda6706),platform=Linux 4.4.0-101-generic x86_64)
```