### PR TITLE
Do not return range_params for empty string inputs…

### DIFF
--- a/lib/blacklight_range_limit/view_helper_override.rb
+++ b/lib/blacklight_range_limit/view_helper_override.rb
@@ -92,9 +92,9 @@
       my_params[:range].select do |_solr_field, range_options|
         next unless range_options
 
-        [range_options['missing'],
-         range_options['begin'],
-         range_options['end']].any?
+        [range_options['missing'].presence,
+         range_options['begin'].presence,
+         range_options['end'].presence].any?
       end
     end
   end

--- a/spec/lib/blacklight_range_limit/view_helper_override_helper_spec.rb
+++ b/spec/lib/blacklight_range_limit/view_helper_override_helper_spec.rb
@@ -87,6 +87,13 @@ RSpec.describe BlacklightRangeLimit::ViewHelperOverride, type: :helper do
           ActionController::Parameters.new(range: { field_name: { 'wrong' => 'data' } })
         )
       ).to eq({})
+
+      expect(
+        helper.send(
+          :range_params,
+          ActionController::Parameters.new(range: { field_name: { 'begin' => '', 'end' => '' } })
+        )
+      ).to eq({})
     end
 
     it 'returns the range parameters that are present' do


### PR DESCRIPTION
…(e.g. like what AdvancedSearch will send).

