### PR TITLE
Allow Blacklight Range Limit to be added to a Blacklight instance tha…

### DIFF
--- a/lib/blacklight_range_limit/engine.rb
+++ b/lib/blacklight_range_limit/engine.rb
@@ -7,7 +7,9 @@ module BlacklightRangeLimit
     # Need to tell asset pipeline to precompile the excanvas
     # we use for IE.
     initializer "blacklight_range_limit.assets", :after => "assets" do
-      Rails.application.config.assets.precompile += %w( flot/excanvas.min.js )
+      if defined? Sprockets
+        Rails.application.config.assets.precompile += %w( flot/excanvas.min.js )
+      end
     end
 
     config.action_dispatch.rescue_responses.merge!(


### PR DESCRIPTION
…t has removed Sprockets

This emulates the pattern that [Blacklight proper employs](https://github.com/projectblacklight/blacklight/blob/b72b2fe2c78aa9278614b826f63c9aa3e4c0862b/lib/blacklight/engine.rb#L25)

Without this conditional my fully de-sprocketed Blacklight application with Rails 5.2 will complain at startup:

```
<snip>
         3: from /Users/cdm32/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.3/lib/rails/initializable.rb:32:in `run'
	 2: from /Users/cdm32/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.3/lib/rails/initializable.rb:32:in `instance_exec'
	 1: from /Users/cdm32/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/blacklight_range_limit-7.9.0/lib/blacklight_range_limit/engine.rb:10:in `block in <class:Engine>'
/Users/cdm32/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.3/lib/rails/railtie/configuration.rb:97:in `method_missing': undefined method `assets' for #<Rails::Application::Configuration:0x00007f837de5d848> (NoMethodError)
Did you mean?  asset_host
```

I guess this would also potentially mean that de-sprocketed Blacklight applications would not support IE for blacklight_range_limit (?). I wonder if this line is even needed anymore, is IE worth supporting still officially?