### PR TITLE
Refactor JavaScript to enable adopter flexibility and customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,33 @@ ourselves yet.
 Also not sure how well the flot select UI works on a touch screen. The slider
 is probably the best touch UI anyway, if it can be made to work well.
 
+## JavaScript Customization
+
+There are two main types of JavaScript implemented for BlacklightRangeLimit:
+ - Initialization and refresh of Range Limit plugin based off of events
+ - Range Limit plugin functionality called from event listeners
+ 
+ The second class of range limit functionality is customizable in your local application by overriding the specified function.
+ 
+ A simple example of this is overriding the display ratio used to create the histogram
+ 
+ ```javascript
+ BlacklightRangeLimit.display_ratio = 1
+```
+
+This will now create a square histogram.
+
+Not only these variables and functions be customized, you can call them based off of custom events in your application.
+
+```javascript
+$('.custom-class').on('doSomething', function() {
+  BlacklightRangeLimit.checkForNeededFacetsToFetch();
+  $(".range_limit .profile .range.slider_js").each(function() {
+    BlacklightRangeLimit.buildSlider(this);
+  });
+});
+```
+
 # Tests
 
 Test coverage is not great, but there are some tests, using rspec.  Run `bundle exec rake ci` or just `bundle exec rake` to seed and

--- a/app/assets/javascripts/blacklight_range_limit.js
+++ b/app/assets/javascripts/blacklight_range_limit.js
@@ -17,4 +17,8 @@
 //= require 'flot/jquery.flot.selection.js'
 //= require 'bootstrap-slider'
 
-//= require_tree './blacklight_range_limit'
+// Ensure that range_limit_shared is loaded first
+//= require 'blacklight_range_limit/range_limit_shared'
+//= require 'blacklight_range_limit/range_limit_plotting'
+//= require 'blacklight_range_limit/range_limit_slider'
+//= require 'blacklight_range_limit/range_limit_distro_facets'

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_distro_facets.js
@@ -1,23 +1,19 @@
 // for Blacklight.onLoad:
 
-/* A custom event "plotDrawn.blacklight.rangeLimit" will be sent when flot plot
-   is (re-)drawn on screen possibly with a new size. target of event will be the DOM element
-   containing the plot.  Used to resize slider to match. */
+/**
+ * Closure functions in this file are mainly concerned with initializing, resizing, and updating
+ * range limit functionality based off of page load, facet opening, page resizing, and otherwise
+ * events.  
+ */
 
 Blacklight.onLoad(function() {
-  // ratio of width to height for desired display, multiply width by this ratio
-  // to get height. hard-coded in for now.
-  var display_ratio = 1/(1.618 * 2); // half a golden rectangle, why not
-  var redrawnEvent = "plotDrawn.blacklight.rangeLimit";
-
-
 
   // Facets already on the page? Turn em into a chart.
   $(".range_limit .profile .distribution.chart_js ul").each(function() {
-      turnIntoPlot($(this).parent());
+      BlacklightRangeLimit.turnIntoPlot($(this).parent());
   });
 
-  checkForNeededFacetsToFetch();
+  BlacklightRangeLimit.checkForNeededFacetsToFetch();
 
   // Listen for twitter bootstrap collapsible open events, to render flot
   // in previously hidden divs on open, if needed.
@@ -31,66 +27,23 @@ Blacklight.onLoad(function() {
       // have width -- right away on show.bs is too soon, but
       // shown.bs is later than we want, we want to start rendering
       // while animation is still in progress.
-      turnIntoPlot(container, 1100);
+      BlacklightRangeLimit.turnIntoPlot(container, 1100);
     }
   });
 
   // When loaded in a modal
   $(Blacklight.modal.modalSelector).on('shown.bs.modal', function() {
     $(this).find(".range_limit .profile .distribution.chart_js ul").each(function() {
-      turnIntoPlot($(this).parent());
+      BlacklightRangeLimit.turnIntoPlot($(this).parent());
     });
 
     // Case when there is no currently selected range
-    checkForNeededFacetsToFetch();
+    BlacklightRangeLimit.checkForNeededFacetsToFetch();
   });
-
-  // Add AJAX fetched range facets if needed, and add a chart to em
-  function checkForNeededFacetsToFetch() {
-    $(".range_limit .profile .distribution a.load_distribution").each(function() {
-      var container = $(this).parent('div.distribution');
-
-      $(container).load($(this).attr('href'), function(response, status) {
-        if ($(container).hasClass("chart_js") && status == "success" ) {
-          turnIntoPlot(container);
-          }
-      });
-    });
-  }
-
-
-  // after a collapsible facet contents is fully shown,
-  // resize the flot chart to current conditions. This way, if you change
-  // browser window size, you can get chart resized to fit by closing and opening
-  // again, if needed.
-
-  function redrawPlot(container) {
-    if (container && container.width() > 0) {
-      // resize the container's height, since width may have changed.
-      container.height( container.width() * display_ratio  );
-
-      // redraw the chart.
-      var plot = container.data("plot");
-      if (plot) {
-        // how to redraw after possible resize?
-        // Cribbed from https://github.com/flot/flot/blob/master/jquery.flot.resize.js
-        plot.resize();
-        plot.setupGrid();
-        plot.draw();
-        // plus trigger redraw of the selection, which otherwise ain't always right
-        // we'll trigger a fake event on one of the boxes
-        var form = $(container).closest(".limit_content").find("form.range_limit");
-        form.find("input.range_begin").trigger("change");
-
-        // send our custom event to trigger redraw of slider
-        $(container).trigger(redrawnEvent);
-      }
-    }
-  }
 
   $("body").on("shown.bs.collapse", function(event) {
     var container =  $(event.target).filter(".facet-content").find(".chart_js");
-    redrawPlot(container);
+    BlacklightRangeLimit.redrawPlot(container);
   });
 
   // debouce borrowed from underscore
@@ -115,197 +68,7 @@ Blacklight.onLoad(function() {
 
   $(window).on("resize", debounce(function() {
     $(".chart_js").each(function(i, container) {
-      redrawPlot($(container));
+      BlacklightRangeLimit.redrawPlot($(container));
     });
   }, 350));
-
-  // second arg, if provided, is a number of ms we're willing to
-  // wait for the container to have width before giving up -- we'll
-  // set 50ms timers to check back until timeout is expired or the
-  // container is finally visible. The timeout is used when we catch
-  // bootstrap show event, but the animation hasn't barely begun yet -- but
-  // we don't want to wait until it's finished, we want to start rendering
-  // as soon as we can.
-  //
-  // We also will
-  function turnIntoPlot(container, wait_for_visible) {
-    // flot can only render in a a div with a defined width.
-    // for instance, a hidden div can't generally be rendered in (although if you set
-    // an explicit width on it, it might work)
-    //
-    // We'll count on later code that catch bootstrap collapse open to render
-    // on show, for currently hidden divs.
-
-    // for some reason width sometimes return negative, not sure
-    // why but it's some kind of hidden.
-    if (container.width() > 0) {
-      var height = container.width() * display_ratio;
-
-      // Need an explicit height to make flot happy.
-      container.height( height )
-
-      areaChart($(container));
-
-      $(container).trigger(redrawnEvent);
-    }
-    else if (wait_for_visible > 0) {
-      setTimeout(function() {
-        turnIntoPlot(container, wait_for_visible - 50);
-      }, 50);
-    }
-  }
-
-     // Takes a div holding a ul of distribution segments produced by
-    // blacklight_range_limit/_range_facets and makes it into
-    // a flot area chart.
-    function areaChart(container) {
-      //flot loaded? And canvas element supported.
-      if (  domDependenciesMet()  ) {
-
-        // Grab the data from the ul div
-        var series_data = new Array();
-        var pointer_lookup = new Array();
-        var x_ticks = new Array();
-        var min = BlacklightRangeLimit.parseNum($(container).find("ul li:first-child span.from").first().data('blrlBegin'));
-        var max = BlacklightRangeLimit.parseNum($(container).find("ul li:last-child span.to").first().data('blrlEnd'));
-
-        $(container).find("ul li").each(function() {
-            var from = BlacklightRangeLimit.parseNum($(this).find("span.from").first().data('blrlBegin'));
-            var to = BlacklightRangeLimit.parseNum($(this).find("span.to").first().data('blrlEnd'));
-            var count = BlacklightRangeLimit.parseNum($(this).find("span.count").text());
-            var avg = (count / (to - from + 1));
-
-
-            //We use the avg as the y-coord, to make the area of each
-            //segment proportional to how many documents it holds.
-            series_data.push( [from, avg ] );
-            series_data.push( [to+1, avg] );
-
-            x_ticks.push(from);
-
-            pointer_lookup.push({'from': from, 'to': to, 'count': count, 'label': $(this).find(".facet_select").html() });
-        });
-        var max_plus_one = BlacklightRangeLimit.parseNum($(container).find("ul li:last-child span.to").text())+1;
-        x_ticks.push( max_plus_one );
-
-
-
-        var plot;
-        var config = $(container).closest('.blrl-plot-config').data('plot-config') || $(container).closest('.facet-limit').data('plot-config') || {};
-
-        try {
-          plot = $.plot($(container), [series_data],
-              $.extend(true, config, {
-              yaxis: {  ticks: [], min: 0, autoscaleMargin: 0.1},
-            //xaxis: { ticks: x_ticks },
-            xaxis: { tickDecimals: 0 }, // force integer ticks
-            series: { lines: { fill: true, steps: true }},
-            grid: {clickable: true, hoverable: true, autoHighlight: false, margin: { left: 0, right: 0 }},
-            selection: {mode: "x"}
-          }));
-        }
-        catch(err) {
-          alert(err);
-        }
-
-        find_segment_for = function_for_find_segment(pointer_lookup);
-        var last_segment = null;
-        $(container).tooltip({'html': true, 'placement': 'bottom', 'trigger': 'manual', 'delay': { show: 0, hide: 100}});
-
-        $(container).bind("plothover", function (event, pos, item) {
-          segment = find_segment_for(pos.x);
-
-          if(segment != last_segment) {
-            var title = find_segment_for(pos.x).label  + ' (' + BlacklightRangeLimit.parseNum(segment.count) + ')';
-            $(container).attr("title", title).tooltip("_fixTitle").tooltip("show");
-
-            last_segment  = segment;
-           }
-        });
-
-        $(container).bind("mouseout", function() {
-          last_segment = null;
-          $(container).tooltip('hide');
-        });
-        $(container).bind("plotclick", function (event, pos, item) {
-            if ( plot.getSelection() == null) {
-              segment = find_segment_for(pos.x);
-              plot.setSelection( normalized_selection(segment.from, segment.to));
-            }
-        });
-        $(container).bind("plotselected plotselecting", function(event, ranges) {
-            if (ranges != null ) {
-              var from = Math.floor(ranges.xaxis.from);
-              var to = Math.floor(ranges.xaxis.to);
-
-              var form = $(container).closest(".limit_content").find("form.range_limit");
-              form.find("input.range_begin").val(from);
-              form.find("input.range_end").val(to);
-
-              var slider_placeholder = $(container).closest(".limit_content").find("[data-slider-placeholder]");
-              if (slider_placeholder) {
-                slider_placeholder.slider("setValue", [from, to+1]);
-              }
-            }
-        });
-
-        var form = $(container).closest(".limit_content").find("form.range_limit");
-        form.find("input.range_begin, input.range_end").change(function () {
-           plot.setSelection( form_selection(form, min, max) , true );
-        });
-        $(container).closest(".limit_content").find(".profile .range").on("slide", function(event, ui) {
-          var values = $(event.target).data("slider").getValue();
-          form.find("input.range_begin").val(values[0]);
-          form.find("input.range_end").val(values[1]);
-          plot.setSelection( normalized_selection(values[0], Math.max(values[0], values[1]-1)), true);
-        });
-
-        // initially entirely selected, to match slider
-        plot.setSelection( {xaxis: { from:min, to:max+0.9999}}  );
-      }
-    }
-
-
-    // Send endpoint to endpoint+0.99999 to have display
-    // more closely approximate limiting behavior esp
-    // at small resolutions. (Since we search on whole numbers,
-    // inclusive, but flot chart is decimal.)
-    function normalized_selection(min, max) {
-      max += 0.99999;
-
-      return {xaxis: { 'from':min, 'to':max}}
-    }
-
-    function form_selection(form, min, max) {
-      var begin_val = BlacklightRangeLimit.parseNum($(form).find("input.range_begin").val());
-      if (isNaN(begin_val) || begin_val < min) {
-        begin_val = min;
-      }
-      var end_val = BlacklightRangeLimit.parseNum($(form).find("input.range_end").val());
-      if (isNaN(end_val) || end_val > max) {
-        end_val = max;
-      }
-
-      return normalized_selection(begin_val, end_val);
-    }
-
-    function function_for_find_segment(pointer_lookup_arr) {
-      return function(x_coord) {
-        for (var i = pointer_lookup_arr.length-1 ; i >= 0 ; i--) {
-          var hash = pointer_lookup_arr[i];
-          if (x_coord >= hash.from)
-            return hash;
-        }
-        return pointer_lookup_arr[0];
-      };
-    }
-
-    // Check if Flot is loaded, and if browser has support for
-    // canvas object, either natively or via IE excanvas.
-    function domDependenciesMet() {
-      var flotLoaded = (typeof $.plot != "undefined");
-      var canvasAvailable = ((typeof(document.createElement('canvas').getContext) != "undefined") || (typeof  window.CanvasRenderingContext2D != 'undefined' || typeof G_vmlCanvasManager != 'undefined'));
-
-      return (flotLoaded && canvasAvailable);
-    }
 });

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_plotting.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_plotting.js
@@ -1,0 +1,173 @@
+// second arg, if provided, is a number of ms we're willing to
+// wait for the container to have width before giving up -- we'll
+// set 50ms timers to check back until timeout is expired or the
+// container is finally visible. The timeout is used when we catch
+// bootstrap show event, but the animation hasn't barely begun yet -- but
+// we don't want to wait until it's finished, we want to start rendering
+// as soon as we can.
+//
+// We also will
+BlacklightRangeLimit.turnIntoPlot = function turnIntoPlot(container, wait_for_visible) {
+  // flot can only render in a a div with a defined width.
+  // for instance, a hidden div can't generally be rendered in (although if you set
+  // an explicit width on it, it might work)
+  //
+  // We'll count on later code that catch bootstrap collapse open to render
+  // on show, for currently hidden divs.
+
+  // for some reason width sometimes return negative, not sure
+  // why but it's some kind of hidden.
+  if (container.width() > 0) {
+    var height = container.width() * BlacklightRangeLimit.display_ratio;
+
+    // Need an explicit height to make flot happy.
+    container.height( height )
+
+    BlacklightRangeLimit.areaChart($(container));
+
+    $(container).trigger(BlacklightRangeLimit.redrawnEvent);
+  }
+  else if (wait_for_visible > 0) {
+    setTimeout(function() {
+      BlacklightRangeLimit.turnIntoPlot(container, wait_for_visible - 50);
+    }, 50);
+  }
+}
+
+// Takes a div holding a ul of distribution segments produced by
+// blacklight_range_limit/_range_facets and makes it into
+// a flot area chart.
+BlacklightRangeLimit.areaChart = function areaChart(container) {
+  //flot loaded? And canvas element supported.
+  if ( BlacklightRangeLimit.domDependenciesMet()  ) {
+
+    // Grab the data from the ul div
+    var series_data = new Array();
+    var pointer_lookup = new Array();
+    var x_ticks = new Array();
+    var min = BlacklightRangeLimit.parseNum($(container).find("ul li:first-child span.from").first().data('blrlBegin'));
+    var max = BlacklightRangeLimit.parseNum($(container).find("ul li:last-child span.to").first().data('blrlEnd'));
+
+    $(container).find("ul li").each(function() {
+        var from = BlacklightRangeLimit.parseNum($(this).find("span.from").first().data('blrlBegin'));
+        var to = BlacklightRangeLimit.parseNum($(this).find("span.to").first().data('blrlEnd'));
+        var count = BlacklightRangeLimit.parseNum($(this).find("span.count").text());
+        var avg = (count / (to - from + 1));
+
+
+        //We use the avg as the y-coord, to make the area of each
+        //segment proportional to how many documents it holds.
+        series_data.push( [from, avg ] );
+        series_data.push( [to+1, avg] );
+
+        x_ticks.push(from);
+
+        pointer_lookup.push({'from': from, 'to': to, 'count': count, 'label': $(this).find(".facet_select").html() });
+    });
+    var max_plus_one = BlacklightRangeLimit.parseNum($(container).find("ul li:last-child span.to").text())+1;
+    x_ticks.push( max_plus_one );
+
+
+
+    var plot;
+    var config = $(container).closest('.blrl-plot-config').data('plot-config') || $(container).closest('.facet-limit').data('plot-config') || {};
+
+    try {
+      plot = $.plot($(container), [series_data],
+          $.extend(true, config, {
+          yaxis: {  ticks: [], min: 0, autoscaleMargin: 0.1},
+        //xaxis: { ticks: x_ticks },
+        xaxis: { tickDecimals: 0 }, // force integer ticks
+        series: { lines: { fill: true, steps: true }},
+        grid: {clickable: true, hoverable: true, autoHighlight: false, margin: { left: 0, right: 0 }},
+        selection: {mode: "x"}
+      }));
+    }
+    catch(err) {
+      alert(err);
+    }
+
+    var find_segment_for = BlacklightRangeLimit.function_for_find_segment(pointer_lookup);
+    var last_segment = null;
+    $(container).tooltip({'html': true, 'placement': 'bottom', 'trigger': 'manual', 'delay': { show: 0, hide: 100}});
+
+    $(container).bind("plothover", function (event, pos, item) {
+      var segment = find_segment_for(pos.x);
+
+      if(segment != last_segment) {
+        var title = find_segment_for(pos.x).label  + ' (' + BlacklightRangeLimit.parseNum(segment.count) + ')';
+        $(container).attr("title", title).tooltip("_fixTitle").tooltip("show");
+
+        last_segment  = segment;
+       }
+    });
+
+    $(container).bind("mouseout", function() {
+      last_segment = null;
+      $(container).tooltip('hide');
+    });
+    $(container).bind("plotclick", function (event, pos, item) {
+        if ( plot.getSelection() == null) {
+          segment = find_segment_for(pos.x);
+          plot.setSelection(BlacklightRangeLimit.normalized_selection(segment.from, segment.to));
+        }
+    });
+    $(container).bind("plotselected plotselecting", function(event, ranges) {
+      if (ranges != null ) {
+        var from = Math.floor(ranges.xaxis.from);
+        var to = Math.floor(ranges.xaxis.to);
+
+        var form = $(container).closest(".limit_content").find("form.range_limit");
+        form.find("input.range_begin").val(from);
+        form.find("input.range_end").val(to);
+
+        var slider_placeholder = $(container).closest(".limit_content").find("[data-slider-placeholder]");
+        if (slider_placeholder) {
+          slider_placeholder.slider("setValue", [from, to+1]);
+        }
+      }
+    });
+
+    var form = $(container).closest(".limit_content").find("form.range_limit");
+    form.find("input.range_begin, input.range_end").change(function () {
+       plot.setSelection( BlacklightRangeLimit.form_selection(form, min, max) , true );
+    });
+    $(container).closest(".limit_content").find(".profile .range").on("slide", function(event, ui) {
+      var values = $(event.target).data("slider").getValue();
+      form.find("input.range_begin").val(values[0]);
+      form.find("input.range_end").val(values[1]);
+      plot.setSelection(BlacklightRangeLimit.normalized_selection(values[0], Math.max(values[0], values[1]-1)), true);
+    });
+
+    // initially entirely selected, to match slider
+    plot.setSelection( {xaxis: { from:min, to:max+0.9999}}  );
+  }
+}
+
+// after a collapsible facet contents is fully shown,
+// resize the flot chart to current conditions. This way, if you change
+// browser window size, you can get chart resized to fit by closing and opening
+// again, if needed.
+BlacklightRangeLimit.redrawPlot = function redrawPlot(container) {
+  if (container && container.width() > 0) {
+    // resize the container's height, since width may have changed.
+    container.height( container.width() * BlacklightRangeLimit.display_ratio  );
+
+    // redraw the chart.
+    var plot = container.data("plot");
+    if (plot) {
+      // how to redraw after possible resize?
+      // Cribbed from https://github.com/flot/flot/blob/master/jquery.flot.resize.js
+      plot.resize();
+      plot.setupGrid();
+      plot.draw();
+      // plus trigger redraw of the selection, which otherwise ain't always right
+      // we'll trigger a fake event on one of the boxes
+      var form = $(container).closest(".limit_content").find("form.range_limit");
+      form.find("input.range_begin").trigger("change");
+
+      // send our custom event to trigger redraw of slider
+      $(container).trigger(BlacklightRangeLimit.redrawnEvent);
+    }
+  }
+}

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_shared.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_shared.js
@@ -1,6 +1,6 @@
-
-// takes a string and parses into an integer, but throws away commas first, to avoid truncation when there is a comma
-// use in place of javascript's native parseInt
+/**
+ * Global BlacklightRangeLimit module setup.
+ */
 !function(global) {
   'use strict';
 
@@ -10,10 +10,74 @@
     this.options = options || {};
   }
 
+  BlacklightRangeLimit.display_ratio = 1/(1.618 * 2); // half a golden rectangle, why not
+  /* A custom event "plotDrawn.blacklight.rangeLimit" will be sent when flot plot
+     is (re-)drawn on screen possibly with a new size. target of event will be the DOM element
+     containing the plot.  Used to resize slider to match. */
+  BlacklightRangeLimit.redrawnEvent = "plotDrawn.blacklight.rangeLimit";
+
+  // takes a string and parses into an integer, but throws away commas first, to avoid truncation when there is a comma
+  // use in place of javascript's native parseInt
   BlacklightRangeLimit.parseNum = function parseNum(str) {
     str = String(str).replace(/[^0-9-]/g, '');
     return parseInt(str, 10);
   };
+
+  BlacklightRangeLimit.form_selection = function form_selection(form, min, max) {
+    var begin_val = BlacklightRangeLimit.parseNum($(form).find("input.range_begin").val());
+    if (isNaN(begin_val) || begin_val < min) {
+      begin_val = min;
+    }
+    var end_val = BlacklightRangeLimit.parseNum($(form).find("input.range_end").val());
+    if (isNaN(end_val) || end_val > max) {
+      end_val = max;
+    }
+
+    return BlacklightRangeLimit.normalized_selection(begin_val, end_val);
+  }
+
+  // Add AJAX fetched range facets if needed, and add a chart to em
+  BlacklightRangeLimit.checkForNeededFacetsToFetch = function checkForNeededFacetsToFetch() {
+    $(".range_limit .profile .distribution a.load_distribution").each(function() {
+      var container = $(this).parent('div.distribution');
+
+      $(container).load($(this).attr('href'), function(response, status) {
+        if ($(container).hasClass("chart_js") && status == "success" ) {
+          BlacklightRangeLimit.turnIntoPlot(container);
+          }
+      });
+    });
+  }
+
+  BlacklightRangeLimit.function_for_find_segment = function function_for_find_segment(pointer_lookup_arr) {
+    return function(x_coord) {
+      for (var i = pointer_lookup_arr.length-1 ; i >= 0 ; i--) {
+        var hash = pointer_lookup_arr[i];
+        if (x_coord >= hash.from)
+          return hash;
+      }
+      return pointer_lookup_arr[0];
+    };
+  }
+
+  // Send endpoint to endpoint+0.99999 to have display
+  // more closely approximate limiting behavior esp
+  // at small resolutions. (Since we search on whole numbers,
+  // inclusive, but flot chart is decimal.)
+  BlacklightRangeLimit.normalized_selection = function normalized_selection(min, max) {
+    max += 0.99999;
+
+    return {xaxis: { 'from':min, 'to':max}}
+  }
+
+  // Check if Flot is loaded, and if browser has support for
+  // canvas object, either natively or via IE excanvas.
+  BlacklightRangeLimit.domDependenciesMet = function domDependenciesMet() {
+    var flotLoaded = (typeof $.plot != "undefined");
+    var canvasAvailable = ((typeof(document.createElement('canvas').getContext) != "undefined") || (typeof  window.CanvasRenderingContext2D != 'undefined' || typeof G_vmlCanvasManager != 'undefined'));
+
+    return (flotLoaded && canvasAvailable);
+  }
 
   BlacklightRangeLimit.noConflict = function noConflict() {
     global.BlacklightRangeLimit = previousBlacklightRangeLimit;

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -3,65 +3,64 @@
 Blacklight.onLoad(function() {
 
   $(".range_limit .profile .range.slider_js").each(function() {
-    buildSlider(this);
+    BlacklightRangeLimit.buildSlider(this);
   });
 
   $(Blacklight.modal.modalSelector).on('shown.bs.modal', function() {
     $(this).find(".range_limit .profile .range.slider_js").each(function() {
-      buildSlider(this);
+      BlacklightRangeLimit.buildSlider(this);
     });
   });
 
-// catch event for redrawing chart, to redraw slider to match width
-$("body").on("plotDrawn.blacklight.rangeLimit", function(event) {
-  var area       = $(event.target).closest(".limit_content.range_limit");
-  var plot       = area.find(".chart_js").data("plot");
-  var slider_el  = area.find(".slider");
+  // catch event for redrawing chart, to redraw slider to match width
+  $("body").on("plotDrawn.blacklight.rangeLimit", function(event) {
+    var area       = $(event.target).closest(".limit_content.range_limit");
+    var plot       = area.find(".chart_js").data("plot");
+    var slider_el  = area.find(".slider");
 
-  if (plot && slider_el) {
+    if (plot && slider_el) {
       slider_el.width(plot.width());
       slider_el.css("display", "block")
-  }
+    }
+  });
 });
 
 // returns two element array min/max as numbers. If there is a limit applied,
 // it's boundaries are are limits. Otherwise, min/max in current result
 // set as sniffed from HTML. Pass in a DOM element for a div.range
 // Will return NaN as min or max in case of error or other weirdness. 
-function min_max(range_element) {
-   var current_limit =  $(range_element).closest(".limit_content.range_limit").find(".current")
-   
-   
-   
-   var min = max = BlacklightRangeLimit.parseNum(current_limit.find(".single").data('blrlSingle'))
-   if ( isNaN(min)) {
-     min = BlacklightRangeLimit.parseNum(current_limit.find(".from").first().data('blrlBegin'));
-     max = BlacklightRangeLimit.parseNum(current_limit.find(".to").first().data('blrlEnd'));
-   }
-  
-   if (isNaN(min) || isNaN(max)) {
-      //no current limit, take from results min max included in spans
-      min = BlacklightRangeLimit.parseNum($(range_element).find(".min").first().text());
-      max = BlacklightRangeLimit.parseNum($(range_element).find(".max").first().text());
-   }
-   return [min, max]
+BlacklightRangeLimit.min_max = function min_max(range_element) {
+  var current_limit =  $(range_element).closest(".limit_content.range_limit").find(".current")
+
+  var min = max = BlacklightRangeLimit.parseNum(current_limit.find(".single").data('blrlSingle'))
+  if ( isNaN(min)) {
+    min = BlacklightRangeLimit.parseNum(current_limit.find(".from").first().data('blrlBegin'));
+    max = BlacklightRangeLimit.parseNum(current_limit.find(".to").first().data('blrlEnd'));
+  }
+
+  if (isNaN(min) || isNaN(max)) {
+    //no current limit, take from results min max included in spans
+    min = BlacklightRangeLimit.parseNum($(range_element).find(".min").first().text());
+    max = BlacklightRangeLimit.parseNum($(range_element).find(".max").first().text());
+  }
+  return [min, max]
 }
 
 
 // Check to see if a value is an Integer
 // see: http://stackoverflow.com/questions/3885817/how-to-check-if-a-number-is-float-or-integer
-function isInt(n) {
+BlacklightRangeLimit.isInt = function isInt(n) {
   return n % 1 === 0;
 }
 
-  function buildSlider(thisContext) {
+BlacklightRangeLimit.buildSlider = function buildSlider(thisContext) {
     var range_element = $(thisContext);
 
-    var boundaries = min_max(thisContext);
+    var boundaries = BlacklightRangeLimit.min_max(thisContext);
     var min = boundaries[0];
     var max = boundaries[1];
 
-    if (isInt(min) && isInt(max)) {
+    if (BlacklightRangeLimit.isInt(min) && BlacklightRangeLimit.isInt(max)) {
       $(thisContext).contents().wrapAll('<div class="sr-only" />');
 
       var range_element = $(thisContext);
@@ -137,4 +136,3 @@ function isInt(n) {
       placeholder_input.slider("setValue", values);
     });
   }
-});


### PR DESCRIPTION
Inspired by some of the analysis and comments in #132, this is a
straight refactor to move JavaScript around. This allows for adopters to
modify BlacklightRangeLimit functions, without having to override entire
files.

For example:

```javascript
BlacklightRangeLimit.display_ratio = 1
```

Would produce a square plot area. Previously this type of customization
was not possible without having to copy and overwrite an entire .js file.

Note: This will require a major version release.