### PR TITLE
Use a blank facet.field solr param instead of deleting.

### DIFF
--- a/lib/blacklight_range_limit/range_limit_builder.rb
+++ b/lib/blacklight_range_limit/range_limit_builder.rb
@@ -78,6 +78,7 @@ module BlacklightRangeLimit
       # Remove all field faceting for efficiency, we won't be using it.
       solr_params.delete("facet.field")
       solr_params.delete("facet.field".to_sym)
+      solr_params["facet.field"] = []
 
       # We don't need any actual rows either
       solr_params[:rows] = 0      


### PR DESCRIPTION
When we outright delete solr_params["facet.field"] this causes Solr to
potentially use default "facet.field" configured in solrconfig.xml thus
nullifying trying to do a more efficient search.

By overriding solr_params["facet.field"] with a blank value then we
effectively override any default value set in solrconfig.xml