### PR TITLE
Change range inputs to type=number

### DIFF
--- a/app/helpers/range_limit_helper.rb
+++ b/app/helpers/range_limit_helper.rb
@@ -14,7 +14,7 @@ module RangeLimitHelper
 
     default = params["range"][solr_field][type] if params["range"] && params["range"][solr_field] && params["range"][solr_field][type]
 
-    html = text_field_tag("range[#{solr_field}][#{type}]", default, :maxlength=>maxlength, :class => "form-control text-center range_#{type}")
+    html = number_field_tag("range[#{solr_field}][#{type}]", default, :maxlength=>maxlength, :class => "form-control text-center range_#{type}")
     html += label_tag("range[#{solr_field}][#{type}]", input_label, class: 'sr-only') if input_label.present?
     html
   end


### PR DESCRIPTION
blacklight_range_limit is documented in readme to only support integer-type values.

Making the input an HTML5 type=number improves UI in several ways:

* Modern browsers will reject non-numeric input on the front-end -- right now, if you enter non-numeric input, it is sent to Solr and results in a Solr 4xx error, and a non-optimal error reporting UX. Better to have standard browser front-end validation for numeric field.

* On some devices such as mobile, input type=number will give you a different numeric on-screen keyboard, which is more convenient entry.