### PR TITLE
filter field validates permitted params with ActionController::Parameters

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,6 +1,7 @@
 # Place any default configuration for solr_wrapper here
 port: 8983
 verbose: true
+version: 8.9.0
 collection:
   dir: solr/conf/
   name: blacklight-core


### PR DESCRIPTION
per proposed Blacklight changes for 7.25.2
CI will fail until solr_wrapper config can pull the latest Solr (now 9.0) from the Apache archive *or* the solr_wrapper config is edited to use version 8.9.0.