### PR TITLE
Display the end year marker on the graph consistently

### DIFF
--- a/app/assets/javascripts/blacklight_range_limit/range_limit_plotting.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_plotting.js
@@ -135,7 +135,7 @@ BlacklightRangeLimit.areaChart = function areaChart(container) {
 
         var slider_placeholder = $(container).closest(".limit_content").find("[data-slider-placeholder]");
         if (slider_placeholder) {
-          slider_placeholder.slider("setValue", [from, to+1]);
+          slider_placeholder.slider("setValue", [from, to]);
         }
       }
     });
@@ -148,11 +148,11 @@ BlacklightRangeLimit.areaChart = function areaChart(container) {
       var values = $(event.target).data("slider").getValue();
       form.find("input.range_begin").val(values[0]);
       form.find("input.range_end").val(values[1]);
-      plot.setSelection(BlacklightRangeLimit.normalized_selection(values[0], Math.max(values[0], values[1]-1)), true);
+      plot.setSelection(BlacklightRangeLimit.normalized_selection(values[0], Math.max(values[0], values[1])), true);
     });
 
     // initially entirely selected, to match slider
-    plot.setSelection( {xaxis: { from:min, to:max+0.9999}}  );
+    plot.setSelection(BlacklightRangeLimit.normalized_selection(min, max));
   }
 }
 

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_plotting.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_plotting.js
@@ -141,8 +141,8 @@ BlacklightRangeLimit.areaChart = function areaChart(container) {
     });
 
     var form = $(container).closest(".limit_content").find("form.range_limit");
-    form.find("input.range_begin, input.range_end").change(function () {
-       plot.setSelection( BlacklightRangeLimit.form_selection(form, min, max) , true );
+    form.find("input.range_begin, input.range_end").on('input', function () {
+      plot.setSelection( BlacklightRangeLimit.form_selection(form, min, max), true );
     });
     $(container).closest(".limit_content").find(".profile .range").on("slide", function(event, ui) {
       var values = $(event.target).data("slider").getValue();

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -135,4 +135,24 @@ BlacklightRangeLimit.buildSlider = function buildSlider(thisContext) {
       values[1] = val;
       placeholder_input.slider("setValue", values);
     });
+
+    begin_el.change(function() {
+      var val1 = BlacklightRangeLimit.parseNum(begin_el.val());
+      var val2 = BlacklightRangeLimit.parseNum(end_el.val());
+
+      if (val2 < val1) {
+        begin_el.val(val2);
+        end_el.val(val1);
+      }
+    });
+
+    end_el.change(function() {
+      var val1 = BlacklightRangeLimit.parseNum(begin_el.val());
+      var val2 = BlacklightRangeLimit.parseNum(end_el.val());
+
+      if (val2 < val1) {
+        begin_el.val(val2);
+        end_el.val(val1);
+      }
+    });
   }

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -115,7 +115,7 @@ BlacklightRangeLimit.buildSlider = function buildSlider(thisContext) {
     end_el.val(max);
 
     begin_el.on('input', function() {
-      var val = BlacklightRangeLimit.parseNum($(thisContext).val());
+      var val = BlacklightRangeLimit.parseNum(this.value);
       if (isNaN(val) || val < min) {
         //for weird data, set slider at min
         val = min;
@@ -126,7 +126,7 @@ BlacklightRangeLimit.buildSlider = function buildSlider(thisContext) {
     });
 
     end_el.on('input', function() {
-      var val = BlacklightRangeLimit.parseNum($(thisContext).val());
+      var val = BlacklightRangeLimit.parseNum(this.value);
       if (isNaN(val) || val > max) {
         //weird entry, set slider to max
         val = max;

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -74,8 +74,8 @@ BlacklightRangeLimit.buildSlider = function buildSlider(thisContext) {
       if (placeholder_input.slider !== undefined) {
         placeholder_input.slider({
           min: min,
-          max: max + 1,
-          value: [min, max + 1],
+          max: max,
+          value: [min, max],
           tooltip: "hide"
         });
 

--- a/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
+++ b/app/assets/javascripts/blacklight_range_limit/range_limit_slider.js
@@ -114,7 +114,7 @@ BlacklightRangeLimit.buildSlider = function buildSlider(thisContext) {
     begin_el.val(min);
     end_el.val(max);
 
-    begin_el.change(function() {
+    begin_el.on('input', function() {
       var val = BlacklightRangeLimit.parseNum($(thisContext).val());
       if (isNaN(val) || val < min) {
         //for weird data, set slider at min
@@ -125,7 +125,7 @@ BlacklightRangeLimit.buildSlider = function buildSlider(thisContext) {
       placeholder_input.slider("setValue", values);
     });
 
-    end_el.change(function() {
+    end_el.on('input', function() {
       var val = BlacklightRangeLimit.parseNum($(thisContext).val());
       if (isNaN(val) || val > max) {
         //weird entry, set slider to max


### PR DESCRIPTION
As I was digging into #187, I noticed several other things about how the graph works that address the reported problem and makes the graph behave consistently.

---

There's been several attempts over the years to fudge the graph data and indicators in order to improve the UX. As best I can tell, this has resulted in a user experience with a couple goals that are in conflict with each other (and led to bugs like #187). An incomplete list of desired UX might be:

- using "inclusive" start and end values
- displaying histogram data so the user can make good selections that return data
- displaying the start + end values on the graph (and sliders, and text input boxes) to give the user lots of ways to fine-tune range selections
- make the start + end values of the graph correspond nicely to the x-axis labels (perhaps in error, as I'll show below)

If we do away with the fudging, as I propose, the major difference (only really visible or problematic at sufficiently narrow windows) is the alignment of the end marker. Before, the behavior was to point the end marker at the corresponding x-axis label:

<img width="420" alt="Screen Shot 2022-06-03 at 08 17 40" src="https://user-images.githubusercontent.com/111218/171883021-543ad455-f5fa-45c9-b83b-dcef50d8a0b3.png">

This makes sense, but as our endpoints are inclusive, this doesn't align correctly with the graph data (where the data for the year 1980 is now to the right of the end marker) or the tooltip (which suggests the selected box is 1975-1979). As such, it might be better to graph the end point without the fudged values: 

<img width="377" alt="Screen Shot 2022-06-03 at 08 19 51" src="https://user-images.githubusercontent.com/111218/171883343-f2d987eb-b2dd-474c-9e2e-b5af687c178f.png">

In doing so, we accept that the user has to think a little harder when selecting the end point using the graph (and have to reason about the apparent mismatch between the input box value + the graph). 

---

Other fixes in this PR were useful for demonstrating the problems and are UX improvements that could be treated separately if needed.

Fixes #187 