### PR TITLE
Do not render constraint for un-configured field

### DIFF
--- a/lib/blacklight_range_limit/view_helper_override.rb
+++ b/lib/blacklight_range_limit/view_helper_override.rb
@@ -89,8 +89,8 @@
     def range_params(my_params = params)
       return {} unless my_params[:range].is_a?(ActionController::Parameters) || my_params[:range].is_a?(Hash)
 
-      my_params[:range].select do |_solr_field, range_options|
-        next unless range_options
+      my_params[:range].select do |solr_field, range_options|
+        next unless range_options && blacklight_config.facet_fields[solr_field].present?
 
         [range_options['missing'].presence,
          range_options['begin'].presence,


### PR DESCRIPTION
Fixes #168

Fixes issue where a constraint gets rendered even though the controller
should not know anything about the particular field whose constraint is
being rendered.

(This is a redo of #169 for the release-7.x branch).