### PR TITLE
Revert "Use `after_initialize` instead of `before_configuration` to play nice with zeitwerk"

### DIFF
--- a/lib/blacklight_range_limit/engine.rb
+++ b/lib/blacklight_range_limit/engine.rb
@@ -16,7 +16,7 @@ module BlacklightRangeLimit
       "BlacklightRangeLimit::InvalidRange" => :not_acceptable
     )
 
-    config.after_initialize do
+    config.before_configuration do
       Blacklight::Configuration::FacetField.prepend BlacklightRangeLimit::FacetFieldConfigOverride
     end
   end


### PR DESCRIPTION
This reverts commit 242732fb47830f576ef232ed94305271686388d0.

`after_initialize` is too late to make that prepend monkeypatching work right.