### PR TITLE
subclass Blacklight::Component to enable template overrides in blacklight installations

### DIFF
--- a/app/components/blacklight_range_limit/range_facet_component.rb
+++ b/app/components/blacklight_range_limit/range_facet_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BlacklightRangeLimit
-  class RangeFacetComponent < ::ViewComponent::Base
+  class RangeFacetComponent < Blacklight::Component
     renders_one :more_link, ->(key:, label:) do
       tag.div class: 'more_facets' do
         link_to t('blacklight.range_limit.view_larger', field_name: label),

--- a/app/components/blacklight_range_limit/range_form_component.rb
+++ b/app/components/blacklight_range_limit/range_form_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BlacklightRangeLimit
-  class RangeFormComponent < ::ViewComponent::Base
+  class RangeFormComponent < Blacklight::Component
     delegate :search_action_path, to: :helpers
 
     def initialize(facet_field:, classes: BlacklightRangeLimit.classes)

--- a/app/components/blacklight_range_limit/range_segments_component.rb
+++ b/app/components/blacklight_range_limit/range_segments_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BlacklightRangeLimit
-  class RangeSegmentsComponent < ::ViewComponent::Base
+  class RangeSegmentsComponent < Blacklight::Component
     def initialize(facet_field:, facet_items: nil, item_component: nil, classes: [])
       super
 


### PR DESCRIPTION
This will allow projects using blacklight_range_limit to customize component views.