### PR TITLE
add deprecation gem to gemspec

### DIFF
--- a/blacklight_range_limit.gemspec
+++ b/blacklight_range_limit.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.license     = 'Apache 2.0'
 
   s.add_dependency 'blacklight', '>= 7.25.2', '< 9'
+  s.add_dependency 'deprecation'
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
add deprecation gem as a dependency in the gemspec. this gem is required by this plugin but no longer included in BL 8's dependencies.