### PR TITLE
Support ViewComponent 3.0, by using with_SLOT api instead of deprecated 2.x slot API

### DIFF
--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -1,9 +1,9 @@
 <%= render(@layout.new(facet_field: @facet_field)) do |component| %>
-  <% component.label do %>
+  <% component.with_label do %>
     <%= @facet_field.label %>
   <% end %>
 
-  <% component.body do %>
+  <% component.with_body do %>
     <div class="limit_content range_limit <%= @facet_field.key %>-config blrl-plot-config">
       <% if @facet_field.selected_range_facet_item %>
         <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field, facet_items: [@facet_field.selected_range_facet_item], classes: ['current']) %>
@@ -37,7 +37,7 @@
 
         <%= render BlacklightRangeLimit::RangeFormComponent.new(facet_field: @facet_field, classes: @classes) %>
 
-        <%= more_link(key: @facet_field.key, label: @facet_field.label) unless @facet_field.in_modal? %>
+        <%= with_more_link(key: @facet_field.key, label: @facet_field.label) unless @facet_field.in_modal? %>
 
         <% if @facet_field.missing_facet_item && !request.xhr? %>
           <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field, facet_items: [@facet_field.missing_facet_item], classes: ['missing', 'subsection']) %>

--- a/blacklight_range_limit.gemspec
+++ b/blacklight_range_limit.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.license     = 'Apache 2.0'
 
   s.add_dependency 'blacklight', '>= 7.25.2', '< 9'
+  # We now use new `with_` slot API, so need view_copmonent >= 2.54.0, through 3.x
+  s.add_dependency 'view_component', ">= 2.54.0", "< 4"
   s.add_dependency 'deprecation'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Blacklight 7.34.0 now allows view_component 3.x (as well as 2.x).  (the release-7.x Blacklight branch had for some time too). 

In trying to upgrade by Blacklight 7 app to BL 7.34.0 and view_component 3.x, I realized that blacklight_range_limit was not yet view_component 3.x compatible. 

To make it so, we have to switch to using the new with_SLOT_NAME slot API, from the 2.x deprecated slot API. 

Deprecated 2.x Slot API was taken away in view_component [3.0.0](https://viewcomponent.org/CHANGELOG.html#v300).  By switching to with_SLOT_NAME API, we can support view_component 3.x.

The with_SLOTNAME API was introduced in view_component [2.54.0](https://viewcomponent.org/CHANGELOG.html#2540) (May 2022).  So we now express a dependency requiring view_component at least 2.54.0. As we do use view_components directly in source code here, it is appropriate to express it as a dependency, instead of just leaving it an indirect dependency.

So blacklight_range_limit still supports view_component 2.x (as long as >= 2.54.0) as well as 3.x. 

I have tested this (with both view_component 2.82.0 and view_component 3.6.0) in my actually existing app as well. 

