### PR TITLE
Only test on Blacklight 7, not 8

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,6 +30,7 @@ jobs:
         - ruby: '3.0'
           rails_version: '7.0.4.1'
     env:
+      BLACKLIGHT_VERSION: "~> 7.0" # only test on BL 7 for now
       RAILS_VERSION: ${{ matrix.rails_version }}
       ENGINE_CART_RAILS_OPTIONS: "--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test ${{ matrix.engine_cart_rails_options }}"
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,14 @@ group :test do
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
 end
 
+# While gemspec allows BL8 and some people are using BL8... the build
+# has never actually passed on BL8 yet. We may choose to run tests on
+# a blacklight version other than the latest allowed by gemspec, to get
+# tests to pass, or to test on older BL still supported here.
+if ENV['BLACKLIGHT_VERSION']
+  gem "blacklight", ENV['BLACKLIGHT_VERSION']
+end
+
 # BEGIN ENGINE_CART BLOCK
 # engine_cart: 2.5.0
 # engine_cart stanza: 2.5.0


### PR DESCRIPTION
While the gemspec allows BL 8.x, and I believe some people *are using* this gem on BL 8 (possibly without the gem's Javascript assets, and/or by manually making local copies of gem assets) (@barmintor) -- the build does not pass on BL 8, and my theory is has never actually passed on BL8?

The gemspec was edited to allow Blacklight 8 (including any future 8.1, 8.2 etc) @ 62874b , on May 22 2022, @cbeer authored @barmintor approved. 

The first Blacklight 8 release was 8.0.0.beta1 on Jan 23 2023.  

I think it's possible this gem has never actually passed a build on a released BL 8?

Currently it does not pass on BL8 for at least two reasons. One I diagnosed and resulted in https://github.com/projectblacklight/blacklight/pull/3088. But even once I ran this build off a BL branch with that fixed -- the rspec then _ran_, but many examples failed complaining `couldn't find file 'blacklight/blacklight' with type 'application/javascript'` -- the current `blacklight_range_limit` install and build is just not compatible with BL8 assets, and i think never has been?

But since some people are already using this gem with BL8 somehow, editing the gemspec seems ill-advised. 

(Also at this point would lead to bad  dependency resolution behavior, where bundler would give someone using BL8 an OLD version of b_l_r that _did_ allow BL8, instead of newer one with improvements and bugfixes). 

So instead of editing gemspec, I have edited Gemfile/build instructions to, for now, only _build_ on BL8. 

Lack of a green build on main are preventing us from fixing other things here, including for use with BL7, such as #239.  If we fix the build green, we can at least make progress, including bugfixes for those using with BL7.  

Once someone fixes the build to work on BL8, the ENV in the `ruby.yml` CI setup can be removed/changed.  

@barmintor , @cbeer, any thoughts?