### PR TITLE
add direct view_component dependency

### DIFF
--- a/blacklight_range_limit.gemspec
+++ b/blacklight_range_limit.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.license     = 'Apache 2.0'
 
   s.add_dependency 'blacklight', '>= 7.25.2', '< 9'
+  s.add_dependency 'view_component', ">= 2.54", "< 4"
   s.add_dependency 'deprecation'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
With #242 to use Slots v2 API, we now require at least view_component 2.54.0, that's when it was introduced. https://viewcomponent.org/CHANGELOG.html#2540

I think we learned from #242 (and analagous things happening with other BL plugins) that if we're using ViewComponent API directly, as we are, we should declare a direct dependency on it, and what we know to work with, instead of just relying on indirect dependency from blacklight. So also adding a cap at `< 4`, since a future 4 might include currently unknown backwards incompat changes that effect this code. I think this is just responsible dependency declaration.

@jcoyne? 
