### PR TITLE
Allow one-sided ranges

### DIFF
--- a/app/components/blacklight_range_limit/range_form_component.rb
+++ b/app/components/blacklight_range_limit/range_form_component.rb
@@ -27,8 +27,8 @@ module BlacklightRangeLimit
 
       default = if @facet_field.selected_range.is_a?(Range)
                   case type
-                  when 'begin' then @facet_field.selected_range.first
-                  when 'end' then @facet_field.selected_range.last
+                  when 'begin' then @facet_field.selected_range.begin
+                  when 'end' then @facet_field.selected_range.end
                   end
                 end
 

--- a/app/helpers/range_limit_helper.rb
+++ b/app/helpers/range_limit_helper.rb
@@ -105,7 +105,7 @@ module RangeLimitHelper
   # :from. Assumes integers for sorting purposes.
   def solr_range_queries_to_a(solr_field)
     range_facet_field_presenter(solr_field).range_queries.map do |item|
-      { from: item.value.first, to: item.value.last, count: item.hits }
+      { from: item.value.begin, to: item.value.end, count: item.hits }
     end
   end
   deprecation_deprecate :solr_range_queries_to_a

--- a/app/presenters/blacklight_range_limit/facet_item_presenter.rb
+++ b/app/presenters/blacklight_range_limit/facet_item_presenter.rb
@@ -15,15 +15,15 @@ module BlacklightRangeLimit
 
       view_context.t(
         range_limit_label_key,
-        begin: format_range_display_value(value.first),
-        begin_value: value.first,
-        end: format_range_display_value(value.last),
-        end_value: value.last
+        begin: format_range_display_value(value.begin),
+        begin_value: value.begin,
+        end: format_range_display_value(value.end),
+        end_value: value.end
       )
     end
 
     def range_limit_label_key
-      if value.first == value.last
+      if value.count == 1
         'blacklight.range_limit.single_html'
       else
         'blacklight.range_limit.range_html'

--- a/app/presenters/blacklight_range_limit/filter_field.rb
+++ b/app/presenters/blacklight_range_limit/filter_field.rb
@@ -22,7 +22,7 @@ module BlacklightRangeLimit
       if value.is_a? Range
         param_key = filters_key
         params[param_key] = (params[param_key] || {}).dup
-        params[param_key][config.key] = { begin: value.first, end: value.last }
+        params[param_key][config.key] = { begin: value.begin, end: value.end }
         new_state.reset(params)
       else
         super
@@ -53,9 +53,9 @@ module BlacklightRangeLimit
       range = if params.dig(param_key, config.key).is_a? Range
         params.dig(param_key, config.key)
       elsif params.dig(param_key, config.key).is_a? Hash
-        b_bound = params.dig(param_key, config.key, :begin).presence
-        e_bound = params.dig(param_key, config.key, :end).presence
-        Range.new(b_bound&.to_i, e_bound&.to_i) if b_bound && e_bound
+        b_bound = params.dig(param_key, config.key, :begin).presence&.to_i
+        e_bound = params.dig(param_key, config.key, :end).presence&.to_i
+        Range.new(b_bound, e_bound) if b_bound || e_bound
       end
 
       f = except.include?(:filters) ? [] : [range].compact

--- a/lib/blacklight_range_limit/range_limit_builder.rb
+++ b/lib/blacklight_range_limit/range_limit_builder.rb
@@ -25,9 +25,15 @@ module BlacklightRangeLimit
         next if range_config[:segments] == false
 
         selected_value = search_state.filter(config.key).values.first
-        range = (selected_value if selected_value.is_a? Range) || range_config[:assumed_boundaries]
+        range = if selected_value.is_a? Range
+          selected_value
+        elsif range_config[:assumed_boundaries]
+          Range.new(*range_config[:assumed_boundaries])
+        else
+          Range.new(nil, nil)
+        end
 
-        add_range_segments_to_solr!(solr_params, field_key, range.first, range.last) if range.present?
+        add_range_segments_to_solr!(solr_params, field_key, range.begin, range.end) if range.begin && range.end
       end
 
       solr_params

--- a/spec/components/range_form_component_spec.rb
+++ b/spec/components/range_form_component_spec.rb
@@ -66,15 +66,15 @@ RSpec.describe BlacklightRangeLimit::RangeFormComponent, type: :component do
         another_field: 'another_value',
         range: {
           another_range: { begin: 128, end: 1024 },
-          key: { begin: selected_range.first, end: selected_range.last }
+          key: { begin: selected_range.begin, end: selected_range.end }
         }
       }      
     end
 
     it 'renders a form for the selected range' do
       expect(rendered).to have_selector('form[action="http://test.host/catalog"][method="get"]')
-        .and have_field('range[key][begin]', type: 'number', with: selected_range.first)
-        .and have_field('range[key][end]', type: 'number', with: selected_range.last)
+        .and have_field('range[key][begin]', type: 'number', with: selected_range.begin)
+        .and have_field('range[key][end]', type: 'number', with: selected_range.end)
         .and have_field('another_field', type: 'hidden', with: 'another_value', visible: false)
         .and have_field('range[another_range][begin]', type: 'hidden', with: 128, visible: false)
         .and have_field('range[another_range][end]', type: 'hidden', with: 1024, visible: false)

--- a/spec/presenters/filter_field_spec.rb
+++ b/spec/presenters/filter_field_spec.rb
@@ -19,8 +19,13 @@ RSpec.describe BlacklightRangeLimit::FilterField do
   describe '#add' do
     it 'adds a new range parameter' do
       new_state = filter.add(1999..2099)
-
       expect(new_state.params.dig(:range, 'some_field')).to include begin: 1999, end: 2099
+
+      new_state = filter.add(1999..nil)
+      expect(new_state.params.dig(:range, 'some_field')).to include begin: 1999, end: nil
+
+      new_state = filter.add(nil..2099)
+      expect(new_state.params.dig(:range, 'some_field')).to include begin: nil, end: 2099
     end
   end
 
@@ -30,8 +35,13 @@ RSpec.describe BlacklightRangeLimit::FilterField do
     describe '#add' do
       it 'replaces the existing range' do
         new_state = filter.add(1999..2099)
-
         expect(new_state.params.dig(:range, 'some_field')).to include begin: 1999, end: 2099
+
+        new_state = filter.add(1999..nil)
+        expect(new_state.params.dig(:range, 'some_field')).to include begin: 1999, end: nil
+
+        new_state = filter.add(nil..2099)
+        expect(new_state.params.dig(:range, 'some_field')).to include begin: nil, end: 2099
       end
     end
 
@@ -62,6 +72,26 @@ RSpec.describe BlacklightRangeLimit::FilterField do
       let(:permitted_params) { blacklight_params.permit_search_params.to_h }
       it 'sanitizes single begin/end values as scalars' do
         expect(permitted_params.dig(:range, 'some_field')).to include 'begin' => '2013', 'end' => '2022'
+      end
+    end
+  end
+
+  context 'with an endless range' do
+    let(:param_values) { { range: { some_field: { begin: '2013', end: '' } } } }
+
+    describe '#values' do
+      it 'converts the parameters to a Range' do
+        expect(filter.values).to eq [2013..nil]
+      end
+    end
+  end
+
+  context 'with an beginless range' do
+    let(:param_values) { { range: { some_field: { begin: '', end: '2022' } } } }
+
+    describe '#values' do
+      it 'converts the parameters to a Range' do
+        expect(filter.values).to eq [nil..2022]
       end
     end
   end


### PR DESCRIPTION
Looking to fix #235, if that original behavior is still desired.

The ability to specify only the start or end date was lost in https://github.com/projectblacklight/blacklight_range_limit/pull/179, which creates a nice system using ranges.

This PR looks to restore that old behavior but depends on making a small change to Blacklight to handle beginless/endless ranges (e.g., `nil..2002`). Something like this:
https://github.com/projectblacklight/blacklight/pull/3213
