### PR TITLE
Redesign input form for applying limits

### DIFF
--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -4,12 +4,12 @@
   <div class="range-limit-input-group">
     <div class="d-flex justify-content-between align-items-end">
       <div class="d-flex flex-column mr-1 me-1">
-        <%= label_tag(begin_input_name, t("blacklight.range_limit.range_begin_short"), class: 'text-muted small') %>
+        <%= label_tag(begin_input_name, t("blacklight.range_limit.range_begin_short"), class: 'text-muted small mb-1') %>
         <%= number_field_tag(begin_input_name, begin_value_default, class: "form-control form-control-sm range_begin") %>
       </div>
 
       <div class="d-flex flex-column ml-1 ms-1">
-        <%= label_tag(end_input_name, t("blacklight.range_limit.range_end_short"), class: 'text-muted small') %>
+        <%= label_tag(end_input_name, t("blacklight.range_limit.range_end_short"), class: 'text-muted small mb-1') %>
         <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm range_end") %>
       </div>
     </div>

--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -5,12 +5,12 @@
     <div class="d-flex justify-content-between align-items-end">
       <div class="d-flex flex-column mr-1 me-1">
         <%= label_tag(begin_input_name, t("blacklight.range_limit.range_begin_short"), class: 'text-muted small') %>
-        <%= number_field_tag(begin_input_name, begin_value_default, class: "form-control form-control-sm text-center range_begin") %>
+        <%= number_field_tag(begin_input_name, begin_value_default, class: "form-control form-control-sm range_begin") %>
       </div>
 
       <div class="d-flex flex-column ml-1 ms-1">
         <%= label_tag(end_input_name, t("blacklight.range_limit.range_end_short"), class: 'text-muted small') %>
-        <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm text-center range_end") %>
+        <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm range_end") %>
       </div>
     </div>
     <div class="d-flex justify-content-end mt-2">

--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -3,14 +3,14 @@
 
   <div class="range-limit-input-group">
     <div class="d-flex justify-content-between align-items-end">
-      <div class="d-flex flex-column">
+      <div class="d-flex flex-column mr-1 me-1">
         <%= label_tag(begin_input_name, t("blacklight.range_limit.range_begin_short"), class: 'text-muted small') %>
-        <%= number_field_tag(begin_input_name, begin_value_default, class: "form-control form-control-sm text-center range_begin mr-1 me-1") %>
+        <%= number_field_tag(begin_input_name, begin_value_default, class: "form-control form-control-sm text-center range_begin") %>
       </div>
 
-      <div class="d-flex flex-column">
+      <div class="d-flex flex-column ml-1 ms-1">
         <%= label_tag(end_input_name, t("blacklight.range_limit.range_end_short"), class: 'text-muted small') %>
-        <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm text-center range_begin ml-1 ms-1") %>
+        <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm text-center range_begin") %>
       </div>
     </div>
     <div class="d-flex justify-content-end mt-2">

--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -1,12 +1,21 @@
 <%= form_tag search_action_path, method: :get, class: [@classes[:form], "range_#{@facet_field.key} d-flex justify-content-center"].join(' ') do %>
   <%= render hidden_search_state %>
 
-  <div class="input-group input-group-sm flex-nowrap range-limit-input-group">
-    <%= render_range_input(:begin, begin_label) %>
-    <%= render_range_input(:end, end_label) %>
-    <div class="input-group-append visually-hidden">
+  <div class="range-limit-input-group">
+    <div class="d-flex justify-content-between align-items-end">
+      <div class="d-flex flex-column">
+        <%= label_tag("range[#{@facet_field.key}][begin]", t("blacklight.range_limit.range_begin_short"), class: 'text-muted small') %>
+
+        <%= render_range_input(:begin) %>
+      </div>
+
+      <div class="d-flex flex-column">
+        <%= label_tag("range[#{@facet_field.key}][end]", t("blacklight.range_limit.range_end_short"), class: 'text-muted small') %>
+        <%= render_range_input(:end) %>
+      </div>
+    </div>
+    <div class="d-flex justify-content-end mt-2">
       <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit], name: nil %>
     </div>
-    <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit] + " sr-only", "aria-hidden": "true", name: nil %>
   </div>
 <% end %>

--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -4,14 +4,13 @@
   <div class="range-limit-input-group">
     <div class="d-flex justify-content-between align-items-end">
       <div class="d-flex flex-column">
-        <%= label_tag("range[#{@facet_field.key}][begin]", t("blacklight.range_limit.range_begin_short"), class: 'text-muted small') %>
-
-        <%= render_range_input(:begin) %>
+        <%= label_tag(begin_input_name, t("blacklight.range_limit.range_begin_short"), class: 'text-muted small') %>
+        <%= number_field_tag(begin_input_name, begin_value_default, class: "form-control form-control-sm text-center range_begin mr-1 me-1") %>
       </div>
 
       <div class="d-flex flex-column">
-        <%= label_tag("range[#{@facet_field.key}][end]", t("blacklight.range_limit.range_end_short"), class: 'text-muted small') %>
-        <%= render_range_input(:end) %>
+        <%= label_tag(end_input_name, t("blacklight.range_limit.range_end_short"), class: 'text-muted small') %>
+        <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm text-center range_begin ml-1 ms-1") %>
       </div>
     </div>
     <div class="d-flex justify-content-end mt-2">

--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -10,7 +10,7 @@
 
       <div class="d-flex flex-column ml-1 ms-1">
         <%= label_tag(end_input_name, t("blacklight.range_limit.range_end_short"), class: 'text-muted small') %>
-        <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm text-center range_begin") %>
+        <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm text-center range_end") %>
       </div>
     </div>
     <div class="d-flex justify-content-end mt-2">

--- a/app/components/blacklight_range_limit/range_form_component.rb
+++ b/app/components/blacklight_range_limit/range_form_component.rb
@@ -9,21 +9,20 @@ module BlacklightRangeLimit
       @classes = classes
     end
 
-    # type is 'begin' or 'end'
-    def render_range_input(type)
-      type = type.to_s
+    def begin_value_default
+      @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.first : @facet_field.min
+    end
 
-      if type == "begin"
-        default = @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.first : @facet_field.min
-        extra_class = "mr-1 me-1" # bootstrap 4 and 5
-      else
-        default = @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.last : @facet_field.max
-        extra_class = "ml-1 ms-1"
-      end
+    def end_value_default
+      @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.last : @facet_field.max
+    end
 
-      html = number_field_tag("range[#{@facet_field.key}][#{type}]", default, class: "form-control form-control-sm text-center range_#{type} #{extra_class}")
+    def begin_input_name
+      "range[#{@facet_field.key}][begin]"
+    end
 
-      html
+    def end_input_name
+      "range[#{@facet_field.key}][end]"
     end
 
     private

--- a/app/components/blacklight_range_limit/range_form_component.rb
+++ b/app/components/blacklight_range_limit/range_form_component.rb
@@ -18,17 +18,19 @@ module BlacklightRangeLimit
     end
 
     # type is 'begin' or 'end'
-    def render_range_input(type, input_label = nil)
+    def render_range_input(type)
       type = type.to_s
 
-      default = if type == "begin"
-        @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.first : @facet_field.min
+      if type == "begin"
+        default = @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.first : @facet_field.min
+        extra_class = "mr-1 me-1" # bootstrap 4 and 5
       else
-        @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.last : @facet_field.max
+        default = @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.last : @facet_field.max
+        extra_class = "ml-1 ms-1"
       end
 
-      html = number_field_tag("range[#{@facet_field.key}][#{type}]", default, class: "form-control text-center range_#{type}")
-      html += label_tag("range[#{@facet_field.key}][#{type}]", input_label, class: 'sr-only visually-hidden') if input_label.present?
+      html = number_field_tag("range[#{@facet_field.key}][#{type}]", default, class: "form-control form-control-sm text-center range_#{type} #{extra_class}")
+
       html
     end
 

--- a/app/components/blacklight_range_limit/range_form_component.rb
+++ b/app/components/blacklight_range_limit/range_form_component.rb
@@ -9,14 +9,6 @@ module BlacklightRangeLimit
       @classes = classes
     end
 
-    def begin_label
-      range_config[:input_label_range_begin] || t("blacklight.range_limit.range_begin", field_label: @facet_field.label)
-    end
-
-    def end_label
-      range_config[:input_label_range_end] || t("blacklight.range_limit.range_end", field_label: @facet_field.label)
-    end
-
     # type is 'begin' or 'end'
     def render_range_input(type)
       type = type.to_s

--- a/config/locales/blacklight_range_limit.ar.yml
+++ b/config/locales/blacklight_range_limit.ar.yml
@@ -5,7 +5,9 @@ ar:
       loading_html: تحميل
       missing: غير معروف
       range_begin: "%{field_label} بداية المدة"
+      range_begin_short: يبدأ
       range_end: "%{field_label} نهاية المدة"
+      range_end_short: نهاية
       range_html: <span class="from" data-blrl-begin="%{begin_value}">%{begin}</span> الى <span class="to" data-blrl-end="%{end_value}">%{end}</span>
       remove_limit: حذف
       results_range_html: تمتد النتائج الحالية من <span class="min">%{min}</span> إلى<span class="max">%{max}</span>

--- a/config/locales/blacklight_range_limit.de.yml
+++ b/config/locales/blacklight_range_limit.de.yml
@@ -5,7 +5,9 @@ de:
       loading_html: Laden...
       missing: Unbekannt
       range_begin: "%{field_label} Bereichsanfang"
+      range_begin_short: Beginnen
       range_end: "%{field_label} Bereichsende"
+      range_end_short: Ende
       range_html: <span class="from" data-blrl-begin="%{begin_value}">%{begin}</span> bis <span class="to" data-blrl-end="%{end_value}">%{end}</span>
       remove_limit: Entfernen
       results_range_html: Aktuelle Ergebnisse reichen von <span class="min">%{min}</span> bis <span class="max">%{max}</span>

--- a/config/locales/blacklight_range_limit.en.yml
+++ b/config/locales/blacklight_range_limit.en.yml
@@ -2,7 +2,9 @@ en:
   blacklight:
     range_limit:
       range_begin: "%{field_label} range begin"
+      range_begin_short: "Begin"
       range_end: "%{field_label} range end"
+      range_end_short: "End"
       submit_limit: 'Apply'
       remove_limit: 'remove'
       missing: 'Unknown'

--- a/config/locales/blacklight_range_limit.en.yml
+++ b/config/locales/blacklight_range_limit.en.yml
@@ -5,7 +5,7 @@ en:
       range_begin_short: "Begin"
       range_end: "%{field_label} range end"
       range_end_short: "End"
-      submit_limit: 'Apply'
+      submit_limit: 'Apply limit'
       remove_limit: 'remove'
       missing: 'Unknown'
       view_distribution: 'View distribution'

--- a/config/locales/blacklight_range_limit.es.yml
+++ b/config/locales/blacklight_range_limit.es.yml
@@ -5,7 +5,9 @@ es:
       loading_html: Cargando...
       missing: Desconocido
       range_begin: Rango %{field_label} inicio
+      range_begin_short: Comenzar
       range_end: Fin del rango %{field_label}
+      range_end_short: Fin
       range_html: <span class="from" data-blrl-begin="%{begin_value}">%{begin}</span> a <span class="to" data-blrl-end="%{end_value}">%{end}</span>
       remove_limit: eliminar
       results_range_html: Los resultados actuales varían de <span class="min">%{min}</span> a <span class="max">%{max}</span>

--- a/config/locales/blacklight_range_limit.it.yml
+++ b/config/locales/blacklight_range_limit.it.yml
@@ -5,7 +5,9 @@ it:
       loading_html: Caricamento...
       missing: Data sconosciuta
       range_begin: "%{field_label} da"
+      range_begin_short: Inizio
       range_end: "%{field_label} a"
+      range_end_short: Fine
       range_html: <span class="from" data-blrl-begin="%{begin_value}">%{begin}</span> a <span class="to" data-blrl-end="%{end_value}">%{end}</span>
       remove_limit: cancella
       results_range_html: Risultati attuali vanno da <span class="min">%{min}</span> a <span class="max">%{max}</span>

--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -19,7 +19,7 @@ module BlacklightRangeLimit
   mattr_accessor :classes
 
   self.classes = {
-    form: 'range_limit_form subsection form-inline',
+    form: 'range_limit_form subsection',
     submit: 'submit btn btn-sm btn-secondary'
   }
 

--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -52,9 +52,7 @@ module BlacklightRangeLimit
         chart_segment_bg_color: 'rgba(54, 162, 235, 0.5)',
         segments: true,
         chart_replaces_text: true,
-        assumed_boundaries: nil,
-        input_label_range_begin: nil,
-        input_label_range_end: nil
+        assumed_boundaries: nil
       },
       filter_class: BlacklightRangeLimit::FilterField,
       presenter: BlacklightRangeLimit::FacetFieldPresenter,

--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -20,7 +20,7 @@ module BlacklightRangeLimit
 
   self.classes = {
     form: 'range_limit_form subsection form-inline',
-    submit: 'submit btn btn-secondary'
+    submit: 'submit btn btn-sm btn-secondary'
   }
 
   # Add element to array only if it's not already there

--- a/spec/components/range_form_component_spec.rb
+++ b/spec/components/range_form_component_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe BlacklightRangeLimit::RangeFormComponent, type: :component do
   context 'with range data' do
     let(:selected_range) { (100..300) }
     let(:search_params) do
-      { 
+      {
         another_field: 'another_value',
         range: {
           another_range: { begin: 128, end: 1024 },
           key: { begin: selected_range.first, end: selected_range.last }
         }
-      }      
+      }
     end
 
     it 'renders a form for the selected range' do

--- a/spec/features/blacklight_range_limit_spec.rb
+++ b/spec/features/blacklight_range_limit_spec.rb
@@ -6,8 +6,8 @@ describe "Blacklight Range Limit" do
     visit search_catalog_path
     expect(page).to have_selector 'input.range_begin'
     expect(page).to have_selector 'input.range_end'
-    expect(page).to have_selector 'label.sr-only[for="range_pub_date_si_begin"]', :text => 'Publication Date Sort range begin'
-    expect(page).to have_selector 'label.sr-only[for="range_pub_date_si_end"]', :text => 'Publication Date Sort range end'
+    expect(page).to have_selector 'label[for="range_pub_date_si_begin"]', :text => I18n.t("blacklight.range_limit.range_begin_short")
+    expect(page).to have_selector 'label[for="range_pub_date_si_end"]', :text => I18n.t("blacklight.range_limit.range_end_short")
     expect(page).to have_button 'Apply'
   end
 
@@ -81,8 +81,9 @@ describe "Blacklight Range Limit with configured input labels" do
 
   it "should show the range limit facet with configured labels" do
     visit '/catalog'
-    expect(page).to have_selector 'label.sr-only[for="range_pub_date_si_begin"]', :text => 'from publication date'
-    expect(page).to have_selector 'label.sr-only[for="range_pub_date_si_end"]', :text => 'to publication date'
+    expect(page).to have_selector 'label[for="range_pub_date_si_begin"]', :text => I18n.t("blacklight.range_limit.range_begin_short")
+    expect(page).to have_selector 'label[for="range_pub_date_si_end"]', :text => I18n.t("blacklight.range_limit.range_end_short")
+
     expect(page).to have_selector 'input#range_pub_date_si_begin'
     expect(page).to have_selector 'input#range_pub_date_si_end'
   end

--- a/spec/features/blacklight_range_limit_spec.rb
+++ b/spec/features/blacklight_range_limit_spec.rb
@@ -71,10 +71,7 @@ describe "Blacklight Range Limit with configured input labels" do
   before do
     CatalogController.blacklight_config = Blacklight::Configuration.new
     CatalogController.configure_blacklight do |config|
-      config.add_facet_field 'pub_date_si', **CatalogController.default_range_config, range_config: {
-        input_label_range_begin: 'from publication date',
-        input_label_range_end: 'to publication date',
-      }
+      config.add_facet_field 'pub_date_si', **CatalogController.default_range_config
       config.default_solr_params[:'facet.field'] = config.facet_fields.keys
     end
   end

--- a/spec/features/run_through_spec.rb
+++ b/spec/features/run_through_spec.rb
@@ -46,10 +46,7 @@ describe 'Run through with javascript', js: true do
       find("input#range_pub_date_si_begin").set(start_range)
       find("input#range_pub_date_si_end").set(end_range)
 
-      # there are two apply buttons cause of handling bootstrap 4/5, with one
-      # hidden off-screen. it's extremely hard to figure out which one is
-      # actually clickable/visible and capybara will let us click on it, annoying.
-      all(:button, "Apply", obscured: false).first.click
+      click_button "Apply limit"
     end
 
     # new page with limit


### PR DESCRIPTION
From (before):

![Screenshot 2024-11-04 at 10 44 30 AM](https://github.com/user-attachments/assets/cd00d80b-5143-4e5f-98af-4521dc3bc294)

To (after): 

![Screenshot 2024-11-04 at 11 05 44 AM](https://github.com/user-attachments/assets/81347342-2fd3-4049-b23c-6441ea11e434)


* A bit challenging to do this with bootstrap utility classes only, as we don't have our own CSS and if possible don't want to introduce it. But did it!

* Required  i18n labels for shorter labels, which I have auto-translated for now with [i18n-tasks](https://github.com/glebm/i18n-tasks)

## Why?

* The old one, in order to work on both Bootstrap 4 and 5, had double labels with one marked sr-only/visual-only
   * Which itself may have accessibility problems, as screen-readers may see double labels
   * And was [breaking for at least some contexts, hiding all labels](https://gitlab.oit.duke.edu/dul-its/dul-arclight/-/merge_requests/380). Just overly complex. 

* On the smallest sidebar size, the old one didn't actually have enough space for input (also could depend on user-agent font-size etc)
    * ![Screenshot 2024-11-04 at 10 44 42 AM](https://github.com/user-attachments/assets/0d2f4a73-3b34-4f82-95d3-e1594c29ec5b)

* Even non-screen-reader users could probably use on-screen labels to explain these boxes