### PR TITLE
make chart.js responsive on screen size change

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ config.add_facet_field 'pub_date', label: 'Publication Year',
                chart_replaces_text: true,
                chart_segment_border_color: "rgba(0,0,0, 0.5)",
                chart_segment_bg_color: "#ccddcc",
+               chart_aspect_ratio: "2"
             }
         )
 ```
@@ -117,6 +118,7 @@ config.add_facet_field 'pub_date', label: 'Publication Year',
 * **chart_replaces_text**: Default true. If false, when the chart is loaded purely textual facets will still remain on-screen too.
 * **chart_segment_border_color** / **chart_segment_bg_color** :
   * Set colors for the edge and fill of the segment bars in the histogram.
+* chart_aspect_ratio: for chart.js, will fill available width then this determines size of chart. defaults to 2
 
 
 ## Javascript dependencies

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -174,6 +174,10 @@ export default class BlacklightRangeLimit {
     this.chartCanvasElement = this.container.ownerDocument.createElement("canvas");
     this.chartCanvasElement.setAttribute("aria-hidden", "true"); // textual facets sr-only are alternative
     this.chartCanvasElement.classList.add("blacklight-range-limit-chart");
+    // We set inline-block for compatibility with container-fluid layouts, e.g. when
+    // Blacklight's config.full_width_layout = true
+    // See: https://github.com/projectblacklight/blacklight_range_limit/pull/269
+    this.chartCanvasElement.style.display = 'inline-block';
     wrapperDiv.prepend(this.chartCanvasElement);
 
     return this.chartCanvasElement;

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -49,8 +49,8 @@ export default class BlacklightRangeLimit {
 
   lineDataPoints = [] // array of objects in Chart.js line chart data format, { x: xVal, y: yVal }
 
-  // <canvas> DOM element
-  chartCanvasElement;
+  container;  // div.range-limit wrapping entire facet display box
+  chartCanvasElement; // <canvas> DOM element
 
   // container should be a `div.range-limit` that will have within it a `.profile .distribution`
   // with textual distributions that will be turned into a histogram chart.
@@ -162,6 +162,7 @@ export default class BlacklightRangeLimit {
     }
 
     const listDiv = this.distributionElement.querySelector(".facet-values");
+    const wrapperDiv = this.container.querySelector("*[data-chart-wrapper=true]");
 
     if (this.chartReplacesText) {
       // We keep the textual facet data as accessible screen-reader, add .sr-only to it though
@@ -169,11 +170,11 @@ export default class BlacklightRangeLimit {
       listDiv.classList.add("visually-hidden");
     }
 
-    // We create a <chart>, insert it into DOM before listDiv
+    // We create a <chart>, insert it into DOM in wrapper
     this.chartCanvasElement = this.container.ownerDocument.createElement("canvas");
     this.chartCanvasElement.setAttribute("aria-hidden", "true"); // textual facets sr-only are alternative
     this.chartCanvasElement.classList.add("blacklight-range-limit-chart");
-    this.distributionElement.insertBefore(this.chartCanvasElement, listDiv);
+    wrapperDiv.prepend(this.chartCanvasElement);
 
     return this.chartCanvasElement;
   }
@@ -185,6 +186,11 @@ export default class BlacklightRangeLimit {
   drawChart(chartCanvasElement) {
     const minX = this.lineDataPoints[0].x;
     const maxX = this.lineDataPoints[this.lineDataPoints.length - 1].x;
+
+    // Get aspect ratio from CSS on wrapper element, has to match.
+    // Getting responsive chart.js to work was a pain! https://github.com/chartjs/Chart.js/issues/11005
+    const wrapper = chartCanvasElement.closest("*[data-chart-wrapper=true]");
+    const aspectRatio = window.getComputedStyle(wrapper)?.getPropertyValue("aspect-ratio") || 2;
 
     const segmentBorderColor = this.container.getAttribute("data-chart-segment-border-color") || 'rgb(54, 162, 235)';
     const segmentBgColor = this.container.getAttribute("data-chart-segment-bg-color") || 'rgba(54, 162, 235, 0.5)';
@@ -200,7 +206,8 @@ export default class BlacklightRangeLimit {
             animationDuration: 0 // duration of animations when hovering an item
         },
         responsiveAnimationDuration: 0,
-
+        aspectRatio: aspectRatio,
+        resizeDelay: 15, // to debounce a bit
         plugins: {
           legend: false,
           tooltip: { enabled: false} // tooltips don't currently show anything useful for our

--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -17,6 +17,11 @@
       <% unless @facet_field.missing_selected? %>
         <!-- this has to be on page if you want calculated facets to show up, JS sniffs it. -->
         <div class="profile mb-3">
+          <%# if was very hard to get chart.js to be succesfully resonsive, required this wrapper!
+          https://github.com/chartjs/Chart.js/issues/11005 %>
+          <div class="chart-wrapper" data-chart-wrapper="true" style="position: relative; width: 100%; aspect-ratio: <%= range_config[:chart_aspect_ratio] %>;">
+          </div>
+
           <% if (min = @facet_field.min) &&
                 (max = @facet_field.max) %>
 

--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -50,6 +50,7 @@ module BlacklightRangeLimit
         chart_js: true,
         chart_segment_border_color: 'rgb(54, 162, 235)',
         chart_segment_bg_color: 'rgba(54, 162, 235, 0.5)',
+        chart_aspect_ratio: 2,
         segments: true,
         chart_replaces_text: true,
         assumed_boundaries: nil,


### PR DESCRIPTION
When you drag the window to a new size, and it changes size of sidebar facet column, we want the chart to resize accordingly. 

While chart.js is supposed to support this with a feature they call "responsive", it's in a confusing situation with either a bug or unclear behvaior, where others are having a lot of trouble doing it too. https://github.com/chartjs/Chart.js/issues/11005

But I think we did it. 

Made the aspect ratio of the chart configurable while we're at it -- before it was always the chart.js default, which was `2` (width 2x height). 

So, with this implementation @seanaery reported a problem at https://github.com/projectblacklight/blacklight_range_limit/pull/266#issuecomment-2448091143

@seanaery, I haven't been able to reproduce your problem -- but I'm using a demo app where the sidebar with facets can only appear at a few specific sizes, it jumps between them at breakpoints. It sounds like you were demo'ing in a non-default app that had a fluid sized sidebar instead maybe?  Is it possible something *else* in your customized dom/css was causing the problem?

While I don't love it, I could be open to applying the solution you came up with if it really does seem necessary for you, as long as it's clearly commented to explain why we're doing it (without fully understanding it!). 
