### PR TITLE
Try Github CI caching solr dist .zip fetch from apache

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -119,7 +119,21 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: "latest"
+
       - name: Install dependencies
         run: bundle install
+
+      # Try to cache solr dist download, which may not save us much time,
+      # but hopes to save us from being throttled/blocked on some runs by
+      # apache foundation servers unhappy that we're downloading the dist zip
+      # so much.
+      - name: Cache solr install
+        uses: actions/cache@v3
+        with:
+          # these paths specified in .solr_wrapper.yml:
+          path: |
+            ci_dl_solr_dist
+          key: ${{ runner.os }}-solr-${{ hashFiles('.solr_wrapper.yml') }}
+
       - name: Run tests
         run: bundle exec rake ci

--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,7 +1,14 @@
 # Place any default configuration for solr_wrapper here
+#
+# We try to use a cacheable and cached location for solr at tmp/solr_dist
+# in Github Actions CI, to avoid excessive downloads from
+# apache (which also get sometimes blocked/rate-limited)
+
 port: 8983
 verbose: true
 version: 9.6.1
+  <% ENV['CI'] && FileUtils.mkdir_p('ci_dl_solr_dist') %>
+download_dir: <%= 'ci_dl_solr_dist' if ENV['CI'] %>
 collection:
   dir: solr/conf/
   name: blacklight-core


### PR DESCRIPTION
We're getting some jobs failing in nearly every CI run with:

```
SolrWrapper::SolrWrapperError: Unable to download solr from https://archive.apache.org/dist/solr/solr/9.6.1/solr-9.6.1.tgz (SolrWrapper::SolrWrapperError)
Failed to open TCP connection to archive.apache.org:443 (execution expired)
/home/runner/work/blacklight_range_limit/blacklight_range_limit/Rakefile:20:in `block in <top (required)>'
/opt/hostedtoolcache/Ruby/3.3.5/x64/bin/bundle:25:in `load'
/opt/hostedtoolcache/Ruby/3.3.5/x64/bin/bundle:25:in `<main>'
```

Trying to cache the download of the solr.tgz in Github Actions cache, so we won't be trying to download it once per job in a CI run, and instead can cache it on Github Actions Cache unless we need a new one -- using hash of .solr_wrapper.yml as key, so if we change what's in there by specifying a different solr version or whatever, it'll bust the cache. 

(This does mean we have to keep specifying solr version in the .solr_wrapper instead of unspecified "latest"). 

So we'll only be downloading from apache when the solr version we want changes, which is also much more respectful to them. 