### PR TITLE
Textual facets in collapsible on screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ config.add_facet_field 'pub_date', label: 'Publication Year',
                assumed_boundaries: [1100, Time.now.year + 2],
                segments: true,
                chart_js: true,
-               chart_replaces_text: true,
+               textual_facets: true,
+               textual_facets_collapsible: true,
                chart_segment_border_color: "rgba(0,0,0, 0.5)",
                chart_segment_bg_color: "#ccddcc",
                chart_aspect_ratio: "2"
@@ -115,7 +116,11 @@ config.add_facet_field 'pub_date', label: 'Publication Year',
   * Default true. If set to false, then distribution segment facets will not be loaded at all,    you'll just get input boxes.
 * **chart_js**:
   * Default true. If false, the Javascript chart is not loaded, you will still get textual facets for buckets.
-* **chart_replaces_text**: Default true. If false, when the chart is loaded purely textual facets will still remain on-screen too.
+* **textual_facets**: Default true. Should we show textual facet list too? Universal design
+  for accessibility, may have accessibilty concerns to turn off.
+* **textual_facets_collapsible**: Put the textual facets in a collapse/expand
+  disclosure. If you set chart_js to false, may make sense to set this to false too, to have
+  textual facets only instead of chart?
 * **chart_segment_border_color** / **chart_segment_bg_color** :
   * Set colors for the edge and fill of the segment bars in the histogram.
 * chart_aspect_ratio: for chart.js, will fill available width then this determines size of chart. defaults to 2

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -53,7 +53,7 @@ export default class BlacklightRangeLimit {
   container;  // div.range-limit wrapping entire facet display box
   chartCanvasElement; // <canvas> DOM element
 
-  // container should be a `div.range-limit` that will have within it a `.profile .distribution`
+  // container should be a `div.range-limit` that will have within it a `.distribution`
   // with textual distributions that will be turned into a histogram chart.
   constructor(container) {
     this.container = container;

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -176,7 +176,7 @@ export default class BlacklightRangeLimit {
       listElement.style["display"] = "none"
     } else if (this.textualFacetsCollapsible) {
       const detailsEl = this.container.ownerDocument.createElement("details");
-      detailsEl.innerHTML = "<summary>Range Interval List</summary>";
+      detailsEl.innerHTML = "<summary>Range List</summary>";
       detailsEl.classList.add("mt-4", "text-muted");
       detailsEl.appendChild( listElement );
       listElement = detailsEl;

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -108,13 +108,13 @@ export default class BlacklightRangeLimit {
         then( response => response.ok ? response.text() : Promise.reject(response)).
         then( responseBody => new DOMParser().parseFromString(responseBody, "text/html")).
         then( responseDom => responseDom.querySelector(".facet-values")).
-        then( element => this.decorateFacetValuesListElement(element)).
-        then( element =>  this.distributionElement.innerHTML = element.outerHTML  ).
+        then( element => this.placeFacetValuesListElement(element)).
         then( _ => { conditonallySetupChart()  }).
         catch( error => {
           console.error(error);
         });
     } else {
+      this.placeFacetValuesListElement(this.distributionElement.querySelector(".facet-values"));
       conditonallySetupChart();
     }
   }
@@ -159,9 +159,17 @@ export default class BlacklightRangeLimit {
     return undefined;
   }
 
-  // Take HTML element with facet list values, and hide and/or
-  // wrap in a collape/disclosure element.
-  decorateFacetValuesListElement(listElement) {
+  // Take HTML element with facet list values
+  //
+  // Possibly hide or wrap it with open/close disclosure, depending on
+  // configuration.
+  //
+  // Place it onto page.
+  placeFacetValuesListElement(listElement) {
+    if (!listElement) {
+      return;
+    }
+
     if (! this.textualFacets) {
       listElement.style["display"] = "none"
     } else if (this.textualFacetsCollapsible) {
@@ -171,7 +179,7 @@ export default class BlacklightRangeLimit {
       listElement = detailsEl;
     }
 
-    return listElement;
+    this.distributionElement.innerHTML  = listElement.outerHTML;
   }
 
   setupDomForChart() {

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -177,7 +177,7 @@ export default class BlacklightRangeLimit {
     } else if (this.textualFacetsCollapsible) {
       const detailsEl = this.container.ownerDocument.createElement("details");
       detailsEl.innerHTML = "<summary>Range Interval List</summary>";
-      detailsEl.classList.add("mt-3", "text-muted");
+      detailsEl.classList.add("mt-4", "text-muted");
       detailsEl.appendChild( listElement );
       listElement = detailsEl;
     }

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -170,11 +170,14 @@ export default class BlacklightRangeLimit {
       return;
     }
 
+    listElement.classList.add("mt-3");
+
     if (! this.textualFacets) {
       listElement.style["display"] = "none"
     } else if (this.textualFacetsCollapsible) {
       const detailsEl = this.container.ownerDocument.createElement("details");
       detailsEl.innerHTML = "<summary>Range Interval List</summary>";
+      detailsEl.classList.add("mt-3");
       detailsEl.appendChild( listElement );
       listElement = detailsEl;
     }

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -62,7 +62,7 @@ export default class BlacklightRangeLimit {
       throw new Error("BlacklightRangeLimit missing argument")
     }
 
-    this.distributionElement = container.querySelector(".profile .distribution")
+    this.distributionElement = container.querySelector(".distribution")
 
     const bounding = container.getBoundingClientRect();
     if (bounding.width > 0 || bounding.height > 0) {

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -177,7 +177,7 @@ export default class BlacklightRangeLimit {
     } else if (this.textualFacetsCollapsible) {
       const detailsEl = this.container.ownerDocument.createElement("details");
       detailsEl.innerHTML = "<summary>Range Interval List</summary>";
-      detailsEl.classList.add("mt-3");
+      detailsEl.classList.add("mt-3", "text-muted");
       detailsEl.appendChild( listElement );
       listElement = detailsEl;
     }

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -115,7 +115,7 @@ export default class BlacklightRangeLimit {
           console.error(error);
         });
     } else {
-      handleOnPageData();
+      conditonallySetupChart();
     }
   }
 

--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -16,32 +16,32 @@
 
       <!-- no results profile if missing is selected -->
       <% unless @facet_field.missing_selected? %>
-        <!-- this has to be on page if you want calculated facets to show up, JS sniffs it. -->
-        <div class="profile mb-3">
-          <%# if was very hard to get chart.js to be succesfully resonsive, required this wrapper!
-          https://github.com/chartjs/Chart.js/issues/11005 %>
-          <div class="chart-wrapper" data-chart-wrapper="true" style="position: relative; width: 100%; aspect-ratio: <%= range_config[:chart_aspect_ratio] %>;">
-          </div>
+        <%# this has to be on page if you want calculated facets to show up, JS sniffs it.
 
-          <% if (min = @facet_field.min) &&
-                (max = @facet_field.max) %>
-
-            <% if range_config[:segments] != false %>
-              <div class="distribution subsection <%= 'chart_js' unless range_config[:chart_js] == false %>">
-                <!-- if  we already fetched segments from solr, display them
-                     here. Otherwise, display a link to fetch them, which JS
-                     will AJAX fetch.  -->
-                <% if @facet_field.range_queries.any? %>
-                  <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field) %>
-                <% else %>
-                  <%= link_to(t('blacklight.range_limit.view_distribution'), range_limit_url(range_start: min, range_end: max), class: "load_distribution", "data-loading-message-html": t('blacklight.range_limit.loading_html')) %>
-                <% end %>
-              </div>
-            <% end %>
-          <% end %>
+          it was very hard to get chart.js to be succesfully resonsive, required this wrapper!
+          https://github.com/chartjs/Chart.js/issues/11005 -%>
+        <div class="chart-wrapper mb-3" data-chart-wrapper="true" style="position: relative; width: 100%; aspect-ratio: <%= range_config[:chart_aspect_ratio] %>;">
         </div>
 
         <%= render BlacklightRangeLimit::RangeFormComponent.new(facet_field: @facet_field, classes: @classes) %>
+
+        <% if (min = @facet_field.min) &&
+              (max = @facet_field.max) %>
+
+          <% if range_config[:segments] != false %>
+            <div class="distribution subsection <%= 'chart_js' unless range_config[:chart_js] == false %>">
+              <!-- if  we already fetched segments from solr, display them
+                   here. Otherwise, display a link to fetch them, which JS
+                   will AJAX fetch.  -->
+              <% if @facet_field.range_queries.any? %>
+                <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field) %>
+              <% else %>
+                <%= link_to(t('blacklight.range_limit.view_distribution'), range_limit_url(range_start: min, range_end: max), class: "load_distribution", "data-loading-message-html": t('blacklight.range_limit.loading_html')) %>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+
 
         <% if @facet_field.missing_facet_item && !request.xhr? && range_config[:segments] != false %>
           <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field, facet_items: [@facet_field.missing_facet_item], classes: ['missing', 'subsection', 'mt-3']) %>

--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -7,7 +7,8 @@
     <div class="limit_content range_limit <%= @facet_field.key %>-config blrl-plot-config"
         data-chart-segment-border-color="<%= range_config[:chart_segment_border_color] %>"
         data-chart-segment-bg-color="<%= range_config[:chart_segment_bg_color] %>"
-        data-chart-replaces-text="<%= range_config[:chart_replaces_text] %>"
+        data-textual-facets="<%= !! range_config[:textual_facets] %>"
+        data-textual-facets-collapsible="<%= !! range_config[:textual_facets_collapsible] %>"
     >
       <% if @facet_field.selected_range_facet_item %>
         <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field, facet_items: [@facet_field.selected_range_facet_item], classes: ['current', 'mb-3']) %>

--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -29,7 +29,7 @@
               (max = @facet_field.max) %>
 
           <% if range_config[:segments] != false %>
-            <div class="distribution subsection <%= 'chart_js' unless range_config[:chart_js] == false %>">
+            <div class="distribution <%= 'chart_js' unless range_config[:chart_js] == false %>">
               <!-- if  we already fetched segments from solr, display them
                    here. Otherwise, display a link to fetch them, which JS
                    will AJAX fetch.  -->
@@ -44,7 +44,7 @@
 
 
         <% if @facet_field.missing_facet_item && !request.xhr? && range_config[:segments] != false %>
-          <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field, facet_items: [@facet_field.missing_facet_item], classes: ['missing', 'subsection', 'mt-3']) %>
+          <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field, facet_items: [@facet_field.missing_facet_item], classes: ['missing', 'mt-3']) %>
         <% end %>
       <% end %>
     </div>

--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -25,11 +25,12 @@ module BlacklightRangeLimit
       range_config: {
         num_segments: 10,
         chart_js: true,
+        textual_facets: true,
+        textual_facets_collapsible: true,
         chart_segment_border_color: 'rgb(54, 162, 235)',
         chart_segment_bg_color: 'rgba(54, 162, 235, 0.5)',
         chart_aspect_ratio: 2,
         segments: true,
-        chart_replaces_text: true,
         assumed_boundaries: nil
       },
       filter_class: BlacklightRangeLimit::FilterField,

--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -15,7 +15,7 @@ module BlacklightRangeLimit
   mattr_accessor :classes
 
   self.classes = {
-    form: 'range_limit_form subsection',
+    form: 'range_limit_form',
     submit: 'submit btn btn-sm btn-secondary'
   }
 

--- a/spec/components/range_facet_component_spec.rb
+++ b/spec/components/range_facet_component_spec.rb
@@ -50,11 +50,6 @@ RSpec.describe BlacklightRangeLimit::RangeFacetComponent, type: :component do
       .and have_selector('div.collapse')
   end
 
-  # This is JS api
-  it 'renders a placeholder profile area' do
-    expect(rendered).to have_selector('div.profile', text: '')
-  end
-
   context 'with min/max' do
     let(:facet_field_params) do
       {
@@ -68,7 +63,7 @@ RSpec.describe BlacklightRangeLimit::RangeFacetComponent, type: :component do
     it "renders a link to fetch distribution info" do
       # need request_url for routing of links generated
       with_request_url '/catalog' do
-        expect(rendered).to have_selector("a.load_distribution[href]")
+        expect(rendered).to have_selector(".distribution a.load_distribution[href]")
       end
     end
   end
@@ -86,9 +81,9 @@ RSpec.describe BlacklightRangeLimit::RangeFacetComponent, type: :component do
     end
 
     it 'renders the range data into the profile' do
-      expect(rendered).to have_selector('.profile li', count: 2)
-        .and have_selector('.profile li', text: '100 to 199')
-        .and have_selector('.profile li', text: '200 to 300')
+      expect(rendered).to have_selector('.distribution li', count: 2)
+        .and have_selector('.distribution li', text: '100 to 199')
+        .and have_selector('.distribution li', text: '200 to 300')
     end
   end
 

--- a/spec/features/run_through_spec.rb
+++ b/spec/features/run_through_spec.rb
@@ -38,7 +38,7 @@ describe 'Run through with javascript', js: true do
       expect(find("input#range_pub_date_si_end").value).to be_present
 
       # expect "missing" facet
-      within 'ul.subsection.missing' do
+      within 'ul.missing' do
         expect(page).to have_link '[Missing]'
       end
 


### PR DESCRIPTION
A "universal design" approach to the need for textual facets corresponding to the chart for low-vision or screen-reader-using users.

Putting all the links in a visually-hidden didn't work, becuase you can't actually put focasable things in visually-hidden without problems or more weirdness, so trying this. 

Put them on all screens, but inside a collapsible header, to avoid noise for those who don't want them.  

Rearranged some DOM and configuration and made some selectors more flexible in the process. 

Still needs i18n on label, and some other cleanup. 
