### PR TITLE
Simply documented and tested config to activate range limit facet

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ package.json-based use will additionally need to point to the matching unreleaes
 You have at least one solr field you want to display as a range limit, that's why you've installed this plugin. In your CatalogController, the facet configuration should look like:
 
 ```ruby
-config.add_facet_field 'pub_date', label: 'Publication Year', **default_range_config
+config.add_facet_field 'pub_date', label: 'Publication Year', range: true
 ```
 
 You should now get range limit display. More complicated configuration is available if desired, see Range Facet Configuration below.
@@ -92,20 +92,18 @@ Note that a drill-down will never require the second request, because boundaries
 There are some additional configuration options that can be passed in facet config in the `range_config` key. You can pass some or all of them like this:
 
 ```ruby
-config.add_facet_field 'pub_date', label: 'Publication Year',
-        **default_range_config.deep_merge(
-            range_config: {
-               num_segments: 6,
-               assumed_boundaries: [1100, Time.now.year + 2],
-               segments: true,
-               chart_js: true,
-               textual_facets: true,
-               textual_facets_collapsible: true,
-               chart_segment_border_color: "rgba(0,0,0, 0.5)",
-               chart_segment_bg_color: "#ccddcc",
-               chart_aspect_ratio: "2"
-            }
-        )
+config.add_facet_field 'pub_date', label: 'Publication Year', range_config: {
+       num_segments: 6,
+       assumed_boundaries: [1100, Time.now.year + 2],
+       segments: true,
+       chart_js: true,
+       textual_facets: true,
+       textual_facets_collapsible: true,
+       chart_segment_border_color: "rgba(0,0,0, 0.5)",
+       chart_segment_bg_color: "#ccddcc",
+       chart_aspect_ratio: "2"
+    }
+)
 ```
 
 * **:num_segments** :

--- a/spec/features/blacklight_range_limit_spec.rb
+++ b/spec/features/blacklight_range_limit_spec.rb
@@ -71,7 +71,7 @@ describe "Blacklight Range Limit with configured input labels" do
   before do
     CatalogController.blacklight_config = Blacklight::Configuration.new
     CatalogController.configure_blacklight do |config|
-      config.add_facet_field 'pub_date_si', **CatalogController.default_range_config
+      config.add_facet_field 'pub_date_si', range: true
       config.default_solr_params[:'facet.field'] = config.facet_fields.keys
     end
   end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -58,7 +58,7 @@ class TestAppGenerator < Rails::Generators::Base
 
   def inject_into_catalog_controller
     inject_into_file 'app/controllers/catalog_controller.rb', after: /config.add_facet_field 'format'.*$/ do
-      "\n    config.add_facet_field 'pub_date_si', label: 'Publication Date Sort', **default_range_config"
+      "\n    config.add_facet_field 'pub_date_si', label: 'Publication Date Sort', range: true"
     end
   end
 end


### PR DESCRIPTION
In the old days, you activated a range limit config with eg

    config.add_facet_field 'pub_date_si', label: 'Publication Date Sort', range: true

At some time that was changed to use a `default_range_config` method mixed into CatalogController...

    config.add_facet_field 'pub_date_si', label: 'Publication Date Sort', **default_range_config

The former simpler way of doing it now works again. And you can override other default config simply by adding the config you want to override:
    
    config.add_facet_field 'pub_date_si', label: 'Publication Date Sort', range: true, range_config: { textual_facets: false }

Changed docs and tests to go back to simpler original way. Also will include specific docs for over-riding Components. 

For now, the mixed-in `default_range_config` method is still available in CatalogControllers.. we could remove it, it would be backwards incompat with any existing config, but it is a major version, any thoughts? I'd just leave it in for now prob... maybe deprecate?
