### PR TITLE
Display properly when there is no data

### DIFF
--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -120,7 +120,7 @@ export default class BlacklightRangeLimit {
     this.rangeBuckets = Array.from(facetListDom.querySelectorAll("ul.facet-values li")).map( li => {
       const from    = this.parseNum(li.querySelector("span.from")?.getAttribute("data-blrl-begin") || li.querySelector("span.single")?.getAttribute("data-blrl-single"));
       const to      = this.parseNum(li.querySelector("span.to")?.getAttribute("data-blrl-end") || li.querySelector("span.single")?.getAttribute("data-blrl-single"));
-      const count   = this.parseNum(li.querySelector("span.facet-count,span.count").innerText);
+      const count   = this.parseNum(li.querySelector("span.facet-count,span.count").textContent);
       const avg     = (count / (to - from + 1));
 
       return {
@@ -178,6 +178,7 @@ export default class BlacklightRangeLimit {
     // Blacklight's config.full_width_layout = true
     // See: https://github.com/projectblacklight/blacklight_range_limit/pull/269
     this.chartCanvasElement.style.display = 'inline-block';
+    wrapperDiv.style.display  = "block"; // un-hide it
     wrapperDiv.prepend(this.chartCanvasElement);
 
     return this.chartCanvasElement;

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -63,6 +63,12 @@ export default class BlacklightRangeLimit {
 
     this.distributionElement = container.querySelector(".profile .distribution")
 
+    // If there is no distribution element on page, it means we don't have data,
+    // nothing to do.
+    if (! this.distributionElement) {
+      return;
+    }
+
     const bounding = container.getBoundingClientRect();
     if (bounding.width > 0 || bounding.height > 0) {
       this.setup(); // visible, init now

--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -19,7 +19,7 @@
         <div class="profile mb-3">
           <%# if was very hard to get chart.js to be succesfully resonsive, required this wrapper!
           https://github.com/chartjs/Chart.js/issues/11005 %>
-          <div class="chart-wrapper" data-chart-wrapper="true" style="position: relative; width: 100%; aspect-ratio: <%= range_config[:chart_aspect_ratio] %>;">
+          <div class="chart-wrapper" data-chart-wrapper="true" style="display: none; position: relative; width: 100%; aspect-ratio: <%= range_config[:chart_aspect_ratio] %>;">
           </div>
 
           <% if (min = @facet_field.min) &&


### PR DESCRIPTION
- keep chart wrapper with explicit aspect-ratio from taking up space when there is no chart
- avoid JS error when there is no data available

## Before


![Screenshot 2024-11-12 at 12 25 05 PM](https://github.com/user-attachments/assets/a2b6c2d0-ebd0-4e4f-af91-ea779a5e64fe)

Plus a JS error. 

## After

![Screenshot 2024-11-12 at 12 29 34 PM](https://github.com/user-attachments/assets/f43e17a8-e206-4147-ad0a-76da9f47aa33)

With no JS error. 