### PR TITLE
Support open-ended ranges

### DIFF
--- a/app/components/blacklight_range_limit/range_form_component.rb
+++ b/app/components/blacklight_range_limit/range_form_component.rb
@@ -10,11 +10,11 @@ module BlacklightRangeLimit
     end
 
     def begin_value_default
-      @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.first : @facet_field.min
+      @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.begin : @facet_field.min
     end
 
     def end_value_default
-      @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.last : @facet_field.max
+      @facet_field.selected_range.is_a?(Range) ? @facet_field.selected_range.end : @facet_field.max
     end
 
     def begin_input_name

--- a/app/presenters/blacklight_range_limit/facet_item_presenter.rb
+++ b/app/presenters/blacklight_range_limit/facet_item_presenter.rb
@@ -15,15 +15,15 @@ module BlacklightRangeLimit
 
       view_context.t(
         range_limit_label_key,
-        begin: format_range_display_value(value.first),
-        begin_value: value.first,
-        end: format_range_display_value(value.last),
-        end_value: value.last
+        begin: format_range_display_value(value.begin),
+        begin_value: value.begin,
+        end: format_range_display_value(value.end),
+        end_value: value.end
       )
     end
 
     def range_limit_label_key
-      if value.first == value.last
+      if value.begin == value.end
         'blacklight.range_limit.single_html'
       else
         'blacklight.range_limit.range_html'

--- a/app/presenters/blacklight_range_limit/filter_field.rb
+++ b/app/presenters/blacklight_range_limit/filter_field.rb
@@ -22,7 +22,7 @@ module BlacklightRangeLimit
       if value.is_a? Range
         param_key = filters_key
         params[param_key] = (params[param_key] || {}).dup
-        params[param_key][config.key] = { begin: value.first, end: value.last }
+        params[param_key][config.key] = { begin: value.begin, end: value.end }
         new_state.reset(params)
       else
         super
@@ -55,7 +55,7 @@ module BlacklightRangeLimit
       elsif params.dig(param_key, config.key).is_a? Hash
         b_bound = params.dig(param_key, config.key, :begin).presence
         e_bound = params.dig(param_key, config.key, :end).presence
-        Range.new(b_bound&.to_i, e_bound&.to_i) if b_bound && e_bound
+        Range.new(b_bound&.to_i, e_bound&.to_i) if b_bound || e_bound
       end
 
       f = except.include?(:filters) ? [] : [range].compact

--- a/lib/blacklight_range_limit/range_limit_builder.rb
+++ b/lib/blacklight_range_limit/range_limit_builder.rb
@@ -25,9 +25,17 @@ module BlacklightRangeLimit
         next unless range_config[:chart_js] || range_config[:textual_facets]
 
         selected_value = search_state.filter(config.key).values.first
-        range = (selected_value if selected_value.is_a? Range) || range_config[:assumed_boundaries]
 
-        add_range_segments_to_solr!(solr_params, field_key, range.first, range.last) if range.present?
+        range = if selected_value.is_a? Range
+          selected_value
+        elsif range_config[:assumed_boundaries]
+          Range.new(*range_config[:assumed_boundaries])
+        else
+          nil
+        end
+
+        # If we have both ends of a range
+        add_range_segments_to_solr!(solr_params, field_key, range.begin, range.end) if range && range.count != Float::INFINITY
       end
 
       solr_params

--- a/lib/blacklight_range_limit/range_limit_builder.rb
+++ b/lib/blacklight_range_limit/range_limit_builder.rb
@@ -80,13 +80,18 @@ module BlacklightRangeLimit
 
         # if it's an one-end range, and condition from original that would use query instead isn't met
         if value.is_a?(Range) && (value.count == Float::INFINITY) && !facet_config&.query
+          # Adapted from
+          # https://github.com/projectblacklight/blacklight/blob/1494bd0884efe7a48623e9b37abe558fa6348e2a/lib/blacklight/solr/search_builder_behavior.rb#L362-L366
+
           solr_field = facet_config.field if facet_config && !facet_config.query
           solr_field ||= facet_field
 
           local_params = []
           local_params << "tag=#{facet_config.tag}" if use_local_params && facet_config && facet_config.tag
 
-          "#{solr_field}:[#{value.begin || "*"} TO #{value.end || "*"}]"
+          prefix = "{!#{local_params.join(' ')}}" unless local_params.empty?
+
+          "#{prefix}#{solr_field}:[#{value.begin || "*"} TO #{value.end || "*"}]"
         else
           super
         end

--- a/spec/features/run_through_spec.rb
+++ b/spec/features/run_through_spec.rb
@@ -61,6 +61,50 @@ describe 'Run through with javascript', js: true do
     end
   end
 
+  context "open-ended range" do
+    it "can search" do
+      visit search_catalog_path
+
+      click_button 'Publication Date Sort'
+
+      within ".facet-limit.blacklight-pub_date_si" do
+        find("input#range_pub_date_si_begin").set("")
+        find("input#range_pub_date_si_end").set(end_range)
+        click_button "Apply limit"
+      end
+
+      expect(page).to have_css(".applied-filter", text: /Publication Date Sort +to #{end_range}/)
+      expect(page).not_to have_text("No entries found")
+      expect(page).to have_css(".document")
+
+      within ".facet-limit.blacklight-pub_date_si" do
+        # expect expandable limits
+        find("summary", text: "Range List").click
+        expect(page).to have_css("details ul.facet-values li")
+      end
+    end
+  end
+
+  context "submitted with empty boundaries" do
+    it "does not apply filter" do
+      visit search_catalog_path
+
+      click_button 'Publication Date Sort'
+
+      within ".facet-limit.blacklight-pub_date_si" do
+        find("input#range_pub_date_si_begin").set("")
+        find("input#range_pub_date_si_end").set("")
+        click_button "Apply limit"
+      end
+      expect(page).not_to have_css(".applied-filter")
+
+      click_button 'Publication Date Sort'
+      within ".facet-limit.blacklight-pub_date_si" do
+        expect(page).not_to have_css(".selected")
+      end
+    end
+  end
+
   context 'when assumed boundaries configured' do
     before do
       CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = {

--- a/spec/presenters/filter_field_spec.rb
+++ b/spec/presenters/filter_field_spec.rb
@@ -19,8 +19,17 @@ RSpec.describe BlacklightRangeLimit::FilterField do
   describe '#add' do
     it 'adds a new range parameter' do
       new_state = filter.add(1999..2099)
-
       expect(new_state.params.dig(:range, 'some_field')).to include begin: 1999, end: 2099
+    end
+
+    it "adds end-less range" do
+      new_state = filter.add(1999..nil)
+      expect(new_state.params.dig(:range, 'some_field')).to include begin: 1999, end: nil
+    end
+
+    it "adds begin-less range" do
+      new_state = filter.add(nil..2099)
+      expect(new_state.params.dig(:range, 'some_field')).to include begin: nil, end: 2099
     end
   end
 
@@ -32,6 +41,12 @@ RSpec.describe BlacklightRangeLimit::FilterField do
         new_state = filter.add(1999..2099)
 
         expect(new_state.params.dig(:range, 'some_field')).to include begin: 1999, end: 2099
+
+        new_state = filter.add(1999..nil)
+        expect(new_state.params.dig(:range, 'some_field')).to include begin: 1999, end: nil
+
+        new_state = filter.add(nil..2099)
+        expect(new_state.params.dig(:range, 'some_field')).to include begin: nil, end: 2099
       end
     end
 
@@ -62,6 +77,26 @@ RSpec.describe BlacklightRangeLimit::FilterField do
       let(:permitted_params) { blacklight_params.permit_search_params.to_h }
       it 'sanitizes single begin/end values as scalars' do
         expect(permitted_params.dig(:range, 'some_field')).to include 'begin' => '2013', 'end' => '2022'
+      end
+    end
+  end
+
+  context 'with an end-less range' do
+    let(:param_values) { { range: { some_field: { begin: '2013', end: '' } } } }
+
+    describe '#values' do
+      it 'converts the parameters to a Range' do
+        expect(filter.values).to eq [2013..nil]
+      end
+    end
+  end
+
+  context 'with an begin-less range' do
+    let(:param_values) { { range: { some_field: { begin: '', end: '2022' } } } }
+
+    describe '#values' do
+      it 'converts the parameters to a Range' do
+        expect(filter.values).to eq [nil..2022]
       end
     end
   end


### PR DESCRIPTION
Fixes #235

Relies on behavior that will be in upcoming Blacklight release from https://github.com/projectblacklight/blacklight/pull/3443 -- but polyfills this behavior in, kind of hackily. (It would have been even hackier to try to keep things no-op on old Blacklights without the fix I think!). Assume BL fix will be in next BL 8.x release, since it's already merged. 

Include some new browser specs meant to try to prevent regression, as this was a breakage tests didn't fix caused by a major refactor previous. 

I started work on this before noticing @taylor-steve's #258, but once I did notice reivewed his code and saw a couple things I had missed actuallyand ideas for improving mine, and borrowed his tests. Thanks @taylor-steve !

- Polyfill Blacklight endless range behavior
- Support one-ended ranges
- add browser specs for open-ended ranges
