### PR TITLE
need to sniff all args from data tags guaranteed BEFORE rendering anything

### DIFF
--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -71,6 +71,15 @@ export default class BlacklightRangeLimit {
       return;
     }
 
+    if (this.container.getAttribute("data-textual-facets") == "false") {
+      this.textualFacets = false;
+    }
+    if (this.container.getAttribute("data-textual-facets-collapsible") == "false") {
+      this.textualFacetsCollapsible = false;
+    }
+
+    this.rangeListHeadingLocalized = this.container.getAttribute("data-range-list-heading-localized") || "Range List";
+
     const bounding = container.getBoundingClientRect();
     if (bounding.width > 0 || bounding.height > 0) {
       this.setup(); // visible, init now
@@ -79,14 +88,6 @@ export default class BlacklightRangeLimit {
       // extra http request to server if it will never be needed!
       this.whenBecomesVisible(container, target => this.setup());
     }
-
-    if (this.container.getAttribute("data-textual-facets") == "false") {
-      this.textualFacets = false;
-    }
-    if (this.container.getAttribute("data-textual-facets-collapsible") == "false") {
-      this.textualFacetsCollapsible = false;
-    }
-    this.rangeListHeadingLocalized = this.container.getAttribute("data-range-list-heading-localized") || "Range List";
   }
 
   // if the range fetch link is still in DOM, fetch ranges from back-end,

--- a/spec/features/run_through_spec.rb
+++ b/spec/features/run_through_spec.rb
@@ -37,6 +37,10 @@ describe 'Run through with javascript', js: true do
       expect(find("input#range_pub_date_si_begin").value).to be_present
       expect(find("input#range_pub_date_si_end").value).to be_present
 
+      # expect expandable limits
+      find("summary", text: "Range List").click
+      expect(page).to have_css("details ul.facet-values li")
+
       # expect "missing" facet
       within 'ul.missing' do
         expect(page).to have_link '[Missing]'
@@ -58,6 +62,10 @@ describe 'Run through with javascript', js: true do
       # min/max from specified range
       expect(find("input#range_pub_date_si_begin").value).to eq start_range
       expect(find("input#range_pub_date_si_end").value).to eq end_range
+
+      # expect expandable limits
+      find("summary", text: "Range List").click
+      expect(page).to have_css("details ul.facet-values li")
     end
   end
 


### PR DESCRIPTION
Fixes 'undefined' as `<details>` heading in some cases.

Make browser specs actually at least smoke-test the new `<details>` behavior added previously.
