### PR TITLE
Don't show chart or textual facets when only one facet bucket,

### DIFF
--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -102,7 +102,8 @@ export default class BlacklightRangeLimit {
     // What we'll do to put the chart on page whether or not we need to load --
     // when query has range limits, we don't need to load, it's already there.
     let conditonallySetupChart = () => {
-      if (this.distributionElement.classList.contains("chart_js")) {
+      // No need to draw chart for only one or none buckets, not useful
+      if (this.distributionElement.classList.contains("chart_js") && this.rangeBuckets.length > 1) {
         this.chartCanvasElement = this.setupDomForChart();
         this.drawChart(this.chartCanvasElement);
       }
@@ -122,8 +123,9 @@ export default class BlacklightRangeLimit {
           console.error(error);
         });
     } else {
-      this.placeFacetValuesListElement(this.distributionElement.querySelector(".facet-values"));
-      this.extractBucketData();
+      const listElement = this.distributionElement.querySelector(".facet-values");
+      this.extractBucketData(listElement);
+      this.placeFacetValuesListElement(listElement);
       conditonallySetupChart();
     }
   }
@@ -181,7 +183,8 @@ export default class BlacklightRangeLimit {
 
     listElement.classList.add("mt-3");
 
-    if (! this.textualFacets) {
+    // No need to show if only 1 or none categories, not useful
+    if (!this.textualFacets || this.rangeBuckets.length <= 1) {
       listElement.style["display"] = "none"
     } else if (this.textualFacetsCollapsible) {
       const detailsEl = this.container.ownerDocument.createElement("details");

--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -103,7 +103,6 @@ export default class BlacklightRangeLimit {
     // when query has range limits, we don't need to load, it's already there.
     let conditonallySetupChart = () => {
       if (this.distributionElement.classList.contains("chart_js")) {
-        this.extractBucketData();
         this.chartCanvasElement = this.setupDomForChart();
         this.drawChart(this.chartCanvasElement);
       }
@@ -116,6 +115,7 @@ export default class BlacklightRangeLimit {
         then( response => response.ok ? response.text() : Promise.reject(response)).
         then( responseBody => new DOMParser().parseFromString(responseBody, "text/html")).
         then( responseDom => responseDom.querySelector(".facet-values")).
+        then( element => this.extractBucketData(element)).
         then( element => this.placeFacetValuesListElement(element)).
         then( _ => { conditonallySetupChart()  }).
         catch( error => {
@@ -123,6 +123,7 @@ export default class BlacklightRangeLimit {
         });
     } else {
       this.placeFacetValuesListElement(this.distributionElement.querySelector(".facet-values"));
+      this.extractBucketData();
       conditonallySetupChart();
     }
   }
@@ -164,7 +165,7 @@ export default class BlacklightRangeLimit {
       this.xTicks.push(this.rangeBuckets[this.rangeBuckets.length - 1].to + 1);
     }
 
-    return undefined;
+    return facetListDom;
   }
 
   // Take HTML element with facet list values

--- a/spec/features/run_through_spec.rb
+++ b/spec/features/run_through_spec.rb
@@ -61,6 +61,28 @@ describe 'Run through with javascript', js: true do
     end
   end
 
+  context "for single dates" do
+    it "does not show chart or facet list" do
+      visit search_catalog_path
+
+      click_button 'Publication Date Sort'
+      last_date = nil
+      within ".facet-limit.blacklight-pub_date_si" do
+        last_date = find("input#range_pub_date_si_begin").value
+
+        find("input#range_pub_date_si_begin").set(last_date)
+        find("input#range_pub_date_si_end").set(last_date)
+        click_button "Apply limit"
+      end
+
+      expect(page).to have_css(".applied-filter", text: /Publication Date Sort.*#{last_date}/)
+      within ".facet-limit.blacklight-pub_date_si" do
+        expect(page).not_to have_css 'canvas'
+        expect(page).not_to have_css 'details'
+      end
+    end
+  end
+
   context 'when assumed boundaries configured' do
     before do
       CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = {


### PR DESCRIPTION
It's not useful to show a histogram with only one bucket, or a facet list with only one value. 

The expected case is when our limit is only one year. 

Closes #224

- move extract data into separate step, so we can use data in deciding to show text facets
- Don't show chart or textual facets when only one facet bucket, not useful
