### PR TITLE
Don't render the range limit facet on zero results pages; fixes #237.

### DIFF
--- a/app/components/blacklight_range_limit/range_facet_component.rb
+++ b/app/components/blacklight_range_limit/range_facet_component.rb
@@ -10,12 +10,22 @@ module BlacklightRangeLimit
       @classes = classes
     end
 
+    # Don't render if we have no values at all -- most commonly on a zero results page.
+    # Normally we'll have at least a min and a max (of values in result set, solr returns),
+    # OR a count of objects missing a value -- if we don't have ANY of that, there is literally
+    # nothing we can display, and we're probably in a zero results situation.
+    def render?
+      (@facet_field.min.present? && @facet_field.max.present?) ||
+        @facet_field.missing_facet_item.present?
+    end
+
     def range_config
       @facet_field.range_config
     end
 
     def range_limit_url(options = {})
-      helpers.main_app.url_for(@facet_field.search_state.to_h.merge(range_field: @facet_field.key, action: 'range_limit').merge(options))
+      helpers.main_app.url_for(@facet_field.search_state.to_h.merge(range_field: @facet_field.key,
+                                                                    action: 'range_limit').merge(options))
     end
 
     def uses_distribution?

--- a/spec/components/range_facet_component_spec.rb
+++ b/spec/components/range_facet_component_spec.rb
@@ -45,29 +45,6 @@ RSpec.describe BlacklightRangeLimit::RangeFacetComponent, type: :component do
     allow(component).to receive(:search_facet_path).and_return('/range/key')
   end
 
-  it 'renders into the default facet layout' do
-    expect(rendered).to have_selector('h3', text: 'My facet field')
-      .and have_selector('div.collapse')
-  end
-
-  context 'with min/max' do
-    let(:facet_field_params) do
-      {
-        range_queries: [],
-        min: 100,
-        max: 300
-      }
-    end
-
-    # This is JS api
-    it "renders a link to fetch distribution info" do
-      # need request_url for routing of links generated
-      with_request_url '/catalog' do
-        expect(rendered).to have_selector(".distribution a.load_distribution[href]")
-      end
-    end
-  end
-
   context 'with range data' do
     let(:facet_field_params) do
       {
@@ -80,21 +57,26 @@ RSpec.describe BlacklightRangeLimit::RangeFacetComponent, type: :component do
       }
     end
 
+    it 'renders into the default facet layout' do
+      expect(rendered).to have_selector('h3', text: 'My facet field')
+        .and have_selector('div.collapse')
+    end
+
     it 'renders the range data into the profile' do
       expect(rendered).to have_selector('.distribution li', count: 2)
         .and have_selector('.distribution li', text: '100 to 199')
         .and have_selector('.distribution li', text: '200 to 300')
     end
-  end
 
-  it 'renders a form for the range' do
-    expect(rendered).to have_selector('form[action="http://test.host/catalog"][method="get"]')
-      .and have_field('range[key][begin]')
-      .and have_field('range[key][end]')
-  end
+    it 'renders a form for the range' do
+      expect(rendered).to have_selector('form[action="http://test.host/catalog"][method="get"]')
+        .and have_field('range[key][begin]')
+        .and have_field('range[key][end]')
+    end
 
-  it 'does not render the missing link if there are no matching documents' do
-    expect(rendered).not_to have_link '[Missing]'
+    it 'does not render the missing link if there are no matching documents' do
+      expect(rendered).not_to have_link '[Missing]'
+    end
   end
 
   context 'with missing documents' do
@@ -109,6 +91,31 @@ RSpec.describe BlacklightRangeLimit::RangeFacetComponent, type: :component do
     it 'renders a facet value for the documents that are missing the field data' do
       expected_facet_query_param = Regexp.new(Regexp.escape({ f: { '-key': ['[* TO *]'] } }.to_param))
       expect(rendered).to have_link '[Missing]', href: expected_facet_query_param
+    end
+  end
+
+  context 'with min/max but no range segments' do
+    let(:facet_field_params) do
+      {
+        range_queries: [],
+        min: 100,
+        max: 300
+      }
+    end
+
+    it "renders a link to fetch distribution info" do
+      # need request_url for routing of links generated
+      with_request_url '/catalog' do
+        expect(rendered).to have_selector(".distribution a.load_distribution[href]")
+      end
+    end
+  end
+
+  context 'with no data to display (e.g., no results page)' do
+    let(:facet_field_params) { { min: nil, max: nil, missing_facet_item: nil } }
+
+    it 'does not render the range limit facet' do
+      expect(component.render?).to be false
     end
   end
 end

--- a/spec/features/blacklight_range_limit_spec.rb
+++ b/spec/features/blacklight_range_limit_spec.rb
@@ -65,6 +65,15 @@ describe "Blacklight Range Limit" do
       expect(page).to_not have_content 'Publication Date Sort'
     end
   end
+
+  context 'when on a zero results found page' do
+    it 'should not render the range limit facet' do
+      visit search_catalog_path(q: 'asdfasdfasdf')
+      expect(page).to_not have_selector '#facets .facet-limit.blacklight-pub_date_si'
+      expect(page).to_not have_selector 'input#range_pub_date_si_begin'
+      expect(page).to_not have_selector 'input#range_pub_date_si_end'
+    end
+  end
 end
 
 describe "Blacklight Range Limit with configured input labels" do


### PR DESCRIPTION
- reorganize impacted existing specs so they have the data they need to render the range_facet_component

This implements @jrochkind 's idea (and annotation) described in #237 with a minor adjustment to ensure the component's predicate method `render?` returns a boolean `true` or `false`. It adds two new specs verifying that the facet doesn't render, and moves a few existing component specs so they continue to pass.
