### PR TITLE
Clean up and make consistent how config is passed to JS

### DIFF
--- a/app/assets/javascripts/blacklight-range-limit/index.js
+++ b/app/assets/javascripts/blacklight-range-limit/index.js
@@ -41,6 +41,7 @@ export default class BlacklightRangeLimit {
     });
   }
 
+  chartEnabled = true;
   textualFacets = true;
   textualFacetsCollapsible = true;
   rangeListHeadingLocalized = undefined;
@@ -71,12 +72,9 @@ export default class BlacklightRangeLimit {
       return;
     }
 
-    if (this.container.getAttribute("data-textual-facets") == "false") {
-      this.textualFacets = false;
-    }
-    if (this.container.getAttribute("data-textual-facets-collapsible") == "false") {
-      this.textualFacetsCollapsible = false;
-    }
+    this.chartEnabled = (this.container.getAttribute("data-chart-enabled") != "false");
+    this.textualFacets = (this.container.getAttribute("data-textual-facets") != "false");
+    this.textualFacetsCollapsible = (this.container.getAttribute("data-textual-facets-collapsible") != "false")
 
     this.rangeListHeadingLocalized = this.container.getAttribute("data-range-list-heading-localized") || "Range List";
 
@@ -104,7 +102,7 @@ export default class BlacklightRangeLimit {
     // when query has range limits, we don't need to load, it's already there.
     let conditonallySetupChart = () => {
       // No need to draw chart for only one or none buckets, not useful
-      if (this.distributionElement.classList.contains("chart_js") && this.rangeBuckets.length > 1) {
+      if (this.chartEnabled && this.rangeBuckets.length > 1) {
         this.chartCanvasElement = this.setupDomForChart();
         this.drawChart(this.chartCanvasElement);
       }

--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -5,6 +5,7 @@
 
   <% component.with_body do %>
     <div class="limit_content range_limit <%= @facet_field.key %>-config blrl-plot-config"
+        data-chart-enabled="<%= !! range_config[:chart_js] %>"
         data-chart-segment-border-color="<%= range_config[:chart_segment_border_color] %>"
         data-chart-segment-bg-color="<%= range_config[:chart_segment_bg_color] %>"
         data-textual-facets="<%= !! range_config[:textual_facets] %>"


### PR DESCRIPTION
Note this interesting possible config choice (was possible before this PR, just was thinking about it when looking at config to clean up). 

With config: 

> range_config: { textual_facets: true, chart_js: false, textual_facets_collapsible: false }

You can get purely textual facets if you want. 

![Screenshot 2024-11-14 at 10 36 38 AM](https://github.com/user-attachments/assets/b4b92a9c-43e0-4894-93cc-bf5ab576795a)

And of course you can also configure `num_buckets` to a smaller number if you'd like. 