### PR TITLE
For open-ended limit, ensure both limit and data min/max are taken account of in calculating range bucket boundaries

### DIFF
--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -36,7 +36,7 @@
             <% if @facet_field.range_queries.any? %>
               <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field) %>
             <% else %>
-              <%= link_to(t('blacklight.range_limit.view_distribution'), range_limit_url(range_start: min, range_end: max), class: "load_distribution", "data-loading-message-html": t('blacklight.range_limit.loading_html')) %>
+              <%= link_to(t('blacklight.range_limit.view_distribution'), load_distribution_link, class: "load_distribution", "data-loading-message-html": t('blacklight.range_limit.loading_html')) %>
             <% end %>
           </div>
         <% end %>

--- a/app/components/blacklight_range_limit/range_facet_component.rb
+++ b/app/components/blacklight_range_limit/range_facet_component.rb
@@ -31,5 +31,17 @@ module BlacklightRangeLimit
     def uses_distribution?
       range_config[:chart_js] || range_config[:textual_facets]
     end
+
+    # URL that will return the distribution list of range seguments
+    def load_distribution_link
+      # For open-ended ranges, the selected range should take priority for the boundary
+      # over actual response min/max. Matters for multi-valued fields.
+      min = @facet_field.selected_range_facet_item&.value&.begin || @facet_field.min
+      max = @facet_field.selected_range_facet_item&.value&.end || @facet_field.max
+
+      return nil unless (min && max)
+
+      range_limit_url(range_start: min, range_end: max)
+    end
   end
 end


### PR DESCRIPTION
In our app we use a multi-valued field for our range limit. In that case, when entering an open-ended limit, range limit could accidentally calculate boundaries for the buckets that exceeded the specified single-end boundary. Because it was ignoring the boundaries unless both ends were present.

Fixed that logic, with tests.
