### PR TITLE
Clamp values between config'd min and max

### DIFF
--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -5,12 +5,22 @@
     <div class="d-flex justify-content-between align-items-end">
       <div class="d-flex flex-column mr-1 me-1">
         <%= label_tag(begin_input_name, t("blacklight.range_limit.range_begin_short"), class: 'text-muted small mb-1') %>
-        <%= number_field_tag(begin_input_name, begin_value_default, class: "form-control form-control-sm range_begin") %>
+        <%= number_field_tag(begin_input_name,
+                              begin_value_default,
+                              min: range_config[:min_value],
+                              max: range_config[:max_value],
+                              class: "form-control form-control-sm range_begin")
+        %>
       </div>
 
       <div class="d-flex flex-column ml-1 ms-1">
         <%= label_tag(end_input_name, t("blacklight.range_limit.range_end_short"), class: 'text-muted small mb-1') %>
-        <%= number_field_tag(end_input_name, end_value_default, class: "form-control form-control-sm range_end") %>
+        <%= number_field_tag(end_input_name,
+                              end_value_default,
+                              min: range_config[:min_value],
+                              max: range_config[:max_value],
+                              class: "form-control form-control-sm range_end")
+        %>
       </div>
     </div>
     <div class="d-flex justify-content-end mt-2">

--- a/lib/blacklight_range_limit.rb
+++ b/lib/blacklight_range_limit.rb
@@ -31,7 +31,9 @@ module BlacklightRangeLimit
         chart_segment_border_color: 'rgb(54, 162, 235)',
         chart_segment_bg_color: 'rgba(54, 162, 235, 0.5)',
         chart_aspect_ratio: 2,
-        assumed_boundaries: nil
+        assumed_boundaries: nil,
+        min_value: -2_147_483_648, # solr intfield min and max
+        max_value: 2_147_483_648
       },
       filter_class: BlacklightRangeLimit::FilterField,
       presenter: BlacklightRangeLimit::FacetFieldPresenter,


### PR DESCRIPTION
To me the main reason to do this is to avoid the possibility of sending something to solr that results in a 500 error. i hate these in my logs, eg created by bots trying random query strings to check for vulnerabilities -- which is why we need a check server-side too, not just client-side. 

- range values clamped by config'd min and max, to avoid solr error
- use html5 min/max on input field for config'd min/max

Closes #289

This PR does not yet have tests. Ideally I think it would have some for server-side (I'm not concerned with testing client-side min/max), but there were no existing tests for the builder, so figuring out the way to scaffold the test si annoying. 

@seanaery are you interested in adding a test to this?
