### PR TITLE
hacky way to keep unpermitted params out of text range facet  links

### DIFF
--- a/app/presenters/blacklight_range_limit/facet_item_presenter.rb
+++ b/app/presenters/blacklight_range_limit/facet_item_presenter.rb
@@ -8,6 +8,14 @@ module BlacklightRangeLimit
       label_for_range || super
     end
 
+    # Very hacky way to keep params used for ajax query for segments out
+    # of our facet links. There oughta be a better way?
+    #
+    # https://github.com/projectblacklight/blacklight_range_limit/issues/296
+    def href(path_options = {})
+      super(path_options.merge(range_end: nil, range_field: nil, range_start: nil))
+    end
+
     private
 
     def label_for_range

--- a/app/presenters/blacklight_range_limit/facet_item_presenter.rb
+++ b/app/presenters/blacklight_range_limit/facet_item_presenter.rb
@@ -9,7 +9,7 @@ module BlacklightRangeLimit
     end
 
     # Very hacky way to keep params used for ajax query for segments out
-    # of our facet links. There oughta be a better way?
+    # of our generated facet links. Sorry this seems to be the best way!
     #
     # https://github.com/projectblacklight/blacklight_range_limit/issues/296
     def href(path_options = {})

--- a/app/presenters/blacklight_range_limit/facet_item_presenter.rb
+++ b/app/presenters/blacklight_range_limit/facet_item_presenter.rb
@@ -13,7 +13,8 @@ module BlacklightRangeLimit
     #
     # https://github.com/projectblacklight/blacklight_range_limit/issues/296
     def href(path_options = {})
-      super(path_options.merge(range_end: nil, range_field: nil, range_start: nil))
+      override_to_nil = BlacklightRangeLimit::ControllerOverride::RANGE_LIMIT_FIELDS.collect { |f| [f, nil] }.to_h
+      super(path_options.merge(override_to_nil))
     end
 
     private

--- a/lib/blacklight_range_limit/controller_override.rb
+++ b/lib/blacklight_range_limit/controller_override.rb
@@ -8,21 +8,18 @@ module BlacklightRangeLimit
 
     RANGE_LIMIT_FIELDS = [:range_end, :range_field, :range_start].freeze
 
-    included do
-      before_action do
-        # Blacklight 7.25+: Allow range limit params if necessary
-        if blacklight_config.search_state_fields
-          missing_keys = RANGE_LIMIT_FIELDS - blacklight_config.search_state_fields
-          blacklight_config.search_state_fields.concat(missing_keys)
-        end
-      end
-    end
-
     # Action method of our own!
     # Delivers a _partial_ that's a display of a single fields range facets.
     # Used when we need a second Solr query to get range facets, after the
     # first found min/max from result set.
     def range_limit
+      # The builder in this action will need our special range_limit fields, so we
+      # must allow them.
+      if blacklight_config.search_state_fields
+        missing_keys = RANGE_LIMIT_FIELDS - blacklight_config.search_state_fields
+        blacklight_config.search_state_fields.concat(missing_keys)
+      end
+
       @facet = blacklight_config.facet_fields[params[:range_field]]
       raise ActionController::RoutingError, 'Not Found' unless @facet&.range
 

--- a/spec/features/run_through_spec.rb
+++ b/spec/features/run_through_spec.rb
@@ -176,4 +176,35 @@ describe 'Run through with javascript', js: true do
       end
     end
   end
+
+  context "Range Limit text facets" do
+    # Make sure it works with strict permitted params
+    around do |example|
+      original = ActionController::Parameters.action_on_unpermitted_parameters
+      ActionController::Parameters.action_on_unpermitted_parameters = :raise
+
+      example.run
+
+      ActionController::Parameters.action_on_unpermitted_parameters = original
+    end
+
+    it "work with strict permitted params" do
+      visit search_catalog_path
+
+      click_button 'Publication Date Sort'
+
+      from_val, to_val = nil, nil
+      within ".facet-limit.blacklight-pub_date_si" do
+        find("summary", text: "Range List").click
+
+        facet_link = first(".facet-values li a")
+        from_val = facet_link.find("span[data-blrl-begin]")["data-blrl-begin"]
+        to_val = facet_link.find("span[data-blrl-end]")["data-blrl-end"]
+
+        facet_link.click
+      end
+
+      expect(page).to have_css(".applied-filter", text: /Publication Date Sort.*#{from_val} to #{to_val}/)
+    end
+  end
 end


### PR DESCRIPTION
It seems like there should be a better way -- I thought Blacklight search_state was only including allow-listed params in the first place but apparently not?  Not sure what a better way would be or if it would require Blacklight architectural changes, but this works for now. Regression test included that was red without this change.

Closes #296
