### PR TITLE
Avoid mutation of range config between tests, revealing fix for assumed_boundaries config

### DIFF
--- a/lib/blacklight_range_limit/range_limit_builder.rb
+++ b/lib/blacklight_range_limit/range_limit_builder.rb
@@ -100,7 +100,9 @@ module BlacklightRangeLimit
 
       range = if selected_value.is_a? Range
         selected_value
-      elsif range_config[:assumed_boundaries]
+      elsif range_config[:assumed_boundaries].is_a?(Range)
+        range_config[:assumed_boundaries]
+      elsif range_config[:assumed_boundaries] # Array of two things please
         Range.new(*range_config[:assumed_boundaries])
       else
         nil

--- a/spec/features/run_through_spec.rb
+++ b/spec/features/run_through_spec.rb
@@ -136,14 +136,15 @@ describe 'Run through with javascript', js: true do
   end
 
   context 'when assumed boundaries configured' do
-    before do
-      CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = {
-        assumed_boundaries: start_range.to_i...end_range.to_i
-      }
-    end
+    around do |example|
+      original = CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config
+      CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = original.merge({
+         :assumed_boundaries=>1900...2100,
+      })
 
-    after do
-      CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = {}
+      example.run
+
+      CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = original
     end
 
     it 'should show the range limit with set boundaries' do
@@ -156,14 +157,15 @@ describe 'Run through with javascript', js: true do
   end
 
   context 'when missing facet item is configured not to show' do
-    before do
-      CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = {
+    around do |example|
+      original = CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config
+      CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = original.merge({
         show_missing_link: false
-      }
-    end
+      })
 
-    after do
-      CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = {}
+      example.run
+
+      CatalogController.blacklight_config.facet_fields['pub_date_si'].range_config = original
     end
 
     it 'should not show the missing facet item' do


### PR DESCRIPTION
First had to change run through tests to avoid mutation of config between tests. 

Once that was fixed, and tests were again testing what was expected -- discovered one of them was a false negative, and the code was actually broken for assumed_boundaries config set as a range, which I guess was meant to be supported? So fixed that. 

