### PR TITLE
trigger CI on PR to any branch, not just main.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: ['**']
 
 jobs:
   test:


### PR DESCRIPTION
Sometimes you want to PR from one branch into a non-main branch, we still want CI.
