### PR TITLE
Schedule weekly CI run

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,8 @@ on:
     branches: [main]
   pull_request:
     branches: ['**']
+  schedule:
+    - cron: "0 2 * * TUE"
 
 jobs:
   test:


### PR DESCRIPTION
Early tuesday morning. We missed failure to pass CI on latest Blacklight beta releases, can we catch it sooner with regularly scheduled CI even if no PRs?  I think this syntax is correct.
