### PR TITLE
fix search_state_fields config *earlier* so app before_actions etc get it

### DIFF
--- a/lib/blacklight_range_limit/controller_override.rb
+++ b/lib/blacklight_range_limit/controller_override.rb
@@ -8,18 +8,17 @@ module BlacklightRangeLimit
 
     RANGE_LIMIT_FIELDS = [:range_end, :range_field, :range_start].freeze
 
+    included do
+      # have to do this in before_action so it's done before any application level
+      # before_actions, that might do something that needs it
+      before_action :_range_limit_add_search_state_fields, only: :range_limit
+    end
+
     # Action method of our own!
     # Delivers a _partial_ that's a display of a single fields range facets.
     # Used when we need a second Solr query to get range facets, after the
     # first found min/max from result set.
     def range_limit
-      # The builder in this action will need our special range_limit fields, so we
-      # must allow them.
-      if blacklight_config.search_state_fields
-        missing_keys = RANGE_LIMIT_FIELDS - blacklight_config.search_state_fields
-        blacklight_config.search_state_fields.concat(missing_keys)
-      end
-
       @facet = blacklight_config.facet_fields[params[:range_field]]
       raise ActionController::RoutingError, 'Not Found' unless @facet&.range
 
@@ -38,6 +37,14 @@ module BlacklightRangeLimit
       @presenter = (@facet.presenter || BlacklightRangeLimit::FacetFieldPresenter).new(@facet, display_facet, view_context)
 
       render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @presenter), layout: !request.xhr?
+    end
+
+    def _range_limit_add_search_state_fields
+      # The builder in this action will need our special range_limit fields, so we
+      # must allow them.
+      blacklight_config.search_state_fields ||= []
+      missing_keys = RANGE_LIMIT_FIELDS - blacklight_config.search_state_fields
+      blacklight_config.search_state_fields.concat(missing_keys)
     end
 
     class_methods do


### PR DESCRIPTION
in my own app, I had a `before_action` that called `search_state.has_constraints?` -- it wound up raising Unpermitted Params error on some blacklight_range_limit params. 

But why, blacklight_range_limit makes sure to configure it's params as permitted in blacklight config!

Aha, because it did so in the action method itself, and my app-specific action was called before it happened.  Moving it to a `before_action` of it's own in this gem fixes the order of execution issue, and has the gem-supplied fix happening before application code. 

Not sure how this error went undetected; maybe I broke it with the new bot challenge config code, but never manually tested os never realized. 

Oops, that makes me realize... maybe this spec _wouldn't_ have caught it since we don't run bot challenge code in tests! Except it does, just tested, test is really red before this fix. Mystery, but good enough. 