### PR TITLE
avoid dependency conflict error by avoiding explicit json require in Gemfile

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,19 +34,22 @@ jobs:
         # that'd be too much. Plus BL can't *generate* every one even though it
         # can be made to work with every one. We test with some good significant
         # representative samples.
+        #
+        # If 'blacklight_version' includes `://`, will be understood as github url,
+        # used for testing off blacklight main.
 
         include:
           # BLACKLIGHT EDGE, can test with Rails 8 beta, importmap and esbuild
           #
 
           - rails_version: "~> 8.0.0"
-            blacklight_version: '{ "git": "https://github.com/projectblacklight/blacklight.git" }'
+            blacklight_version: 'https://github.com/projectblacklight/blacklight.git'
             ruby: "3.3"
             additional_name: "/ importmap-rails"
             additional_engine_cart_rails_options: "--css=bootstrap"
 
           - rails_version: "~> 8.0.0"
-            blacklight_version: '{ "git": "https://github.com/projectblacklight/blacklight.git" }'
+            blacklight_version: 'https://github.com/projectblacklight/blacklight.git'
             ruby: "3.3"
             additional_name: "/ esbuild"
             additional_engine_cart_rails_options: "--css=bootstrap --javascript=esbuild"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'json'
 
 source 'https://rubygems.org'
 
@@ -15,9 +14,8 @@ end
 # a blacklight version other than the latest allowed by gemspec, to get
 # tests to pass, or to test on older BL still supported here.
 if ENV['BLACKLIGHT_VERSION']
-  # allow direct git and other with serialized json kw args
-  if ENV['BLACKLIGHT_VERSION'].start_with?("{")
-    gem "blacklight", **JSON.parse(ENV['BLACKLIGHT_VERSION'])
+  if ENV['BLACKLIGHT_VERSION'].include?("://")
+    gem "blacklight", git: ENV['BLACKLIGHT_VERSION']
   else
     gem "blacklight", ENV['BLACKLIGHT_VERSION']
   end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,10 +1,8 @@
 gem 'rails-controller-testing'
 
 if ENV['BLACKLIGHT_VERSION']
-  # allow direct git and other with serialized json kw args
-  require 'json'
-  if ENV['BLACKLIGHT_VERSION'].start_with?("{")
-    gem "blacklight", **JSON.parse(ENV['BLACKLIGHT_VERSION'])
+  if ENV['BLACKLIGHT_VERSION'].include?("://")
+    gem "blacklight", git: ENV['BLACKLIGHT_VERSION']
   else
     gem "blacklight", ENV['BLACKLIGHT_VERSION']
   end


### PR DESCRIPTION
`You have already activated json 2.15.0, but your Gemfile requires json 2.13.2` is what we were getting in CI runs. 

Comes about because we are trying to parse json in the gemfile to determine what dependencies we want to specify, for CI. 

Somehow we were activating a system json for use in the Gemfile production that was not hte same json Gemfile dependency resolution arrived at. 

Not sure what the workaround is, may have to totally change this system. 