### PR TITLE
Lock to bundler < 4 to fix CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -166,7 +166,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: ${{ matrix.bundler != '' && matrix.bundler || 'latest' }}
+          #bundler: ${{ matrix.bundler != '' && matrix.bundler || 'latest' }}
+          # Bundler locked to <4, see https://github.com/projectblacklight/blacklight_range_limit/pull/328
+          bundler: ${{ matrix.bundler != '' && matrix.bundler || '2.7.2' }}
+
 
       - name: Install dependencies
         run: bundle install


### PR DESCRIPTION
CI is broken in weekly scheduled build at https://github.com/projectblacklight/blacklight_range_limit/actions/runs/20050712705/job/57505810337

For TWO reasons, although perhaps both related to recent release of rubygems and bundler 4, which may be auto-used? (note there was no bundler 3.x, they skipped from bundler 2.7.2 to 4, to have a match with rubygems version 4). 

1. On very old Blacklight 7, the BL generator uses `Bundler.with_clean_env`, which is no longer avail in bundler 4 (should use `with_unbundled_env` instead). So we just tell CI to use bundler 2.7.2 with BL 7 CI runs?

2. On Rails 8 and following, our asset generator is raising "Could not identify asset_delivery_mode, try supplying --asset-delivery-mode=[importmap-rails|yarn-package]", haven't figured out why, guessing it has something to do with new rubygems/bundler I dunno, investigating.  