### PR TITLE
Add inputmode=numeric to range fields

### DIFF
--- a/app/components/blacklight_range_limit/range_input_component.html.erb
+++ b/app/components/blacklight_range_limit/range_input_component.html.erb
@@ -4,6 +4,7 @@
     @input_value,
     min: @min_value,
     max: @max_value,
+    inputmode: 'numeric',
     class: "form-control form-control-sm #{@css_class}" %>
 </div>
 


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#numeric

This helps UX on mobile safari, which otherwise shows the keyboard input.